### PR TITLE
Fixes import standard geometry table view creation

### DIFF
--- a/lib/modules/wdpa/release.rb
+++ b/lib/modules/wdpa/release.rb
@@ -49,7 +49,7 @@ class Wdpa::Release
     create_query = "CREATE OR REPLACE VIEW #{IMPORT_VIEW_NAME} AS "
 
     select_queries = []
-    geometry_tables.each do |geometry_table, _|
+    geometry_tables.each do |_, geometry_table|
       select_queries << "SELECT #{attributes} FROM #{geometry_table}"
     end
 

--- a/test/unit/wdpa/release_test.rb
+++ b/test/unit/wdpa/release_test.rb
@@ -174,16 +174,19 @@ class TestWdpaRelease < ActiveSupport::TestCase
 
   test '.create_import_view executes a DB command to create a view with
    the imported PAs' do
-    geometry_tables = {polygons: 'polygon_june2014', points: 'points_june2014'}
-    Wdpa::Release.any_instance.expects(:geometry_tables).returns(geometry_tables.values)
+    geometry_tables = {
+      "polygons" => "std_poly",
+      "point" => "std_point"
+    }
+    Wdpa::Release.any_instance.expects(:geometry_tables).returns(geometry_tables)
 
     Wdpa::DataStandard.expects(:common_attributes).returns([:a, :b])
 
     create_view_command = """
       CREATE OR REPLACE VIEW imported_protected_areas AS
-        SELECT a, b FROM #{geometry_tables[:polygons]}
+        SELECT a, b FROM #{geometry_tables["polygons"]}
         UNION ALL
-        SELECT a, b FROM #{geometry_tables[:points]}
+        SELECT a, b FROM #{geometry_tables["point"]}
     """.squish
 
     db = ActiveRecord::Base.connection


### PR DESCRIPTION
View creator was using the pre-standardisation table names, which no
longer exist at this point.
