### PR TITLE
PA Slugs include designation as well

### DIFF
--- a/app/models/protected_area.rb
+++ b/app/models/protected_area.rb
@@ -12,6 +12,8 @@ class ProtectedArea < ActiveRecord::Base
   belongs_to :designation
   belongs_to :wikipedia_article
 
+  after_create :create_slug
+
   def bounds
     rgeo_factory = RGeo::Geos.factory srid: 4326
     bounding_box = RGeo::Cartesian::BoundingBox.new rgeo_factory
@@ -21,5 +23,12 @@ class ProtectedArea < ActiveRecord::Base
       [bounding_box.min_y, bounding_box.min_x],
       [bounding_box.max_y, bounding_box.max_x]
     ]
+  end
+
+  private
+
+  def create_slug
+    updated_slug = [name, designation.try(:name)].join(' ').parameterize
+    update_attributes(slug: updated_slug)
   end
 end

--- a/lib/modules/wdpa/attribute.rb
+++ b/lib/modules/wdpa/attribute.rb
@@ -6,7 +6,6 @@ class Wdpa::Attribute
     string:   -> (value) { value.to_s },
     float:    -> (value) { value.to_f },
     csv:      -> (value) { value.split(',').map(&:strip) },
-    slug:     -> (value) { value.parameterize },
     year:     -> (value) {
       value = value.to_s
       # Postgres cannot handle zero dates, and the WDPA stores

--- a/lib/modules/wdpa/data_standard.rb
+++ b/lib/modules/wdpa/data_standard.rb
@@ -2,10 +2,7 @@ class Wdpa::DataStandard
   STANDARD_ATTRIBUTES = {
     :wdpaid       => {name: :wdpa_id, type: :integer},
     :wdpa_pid     => {name: :wdpa_parent_id, type: :integer},
-    :name         => [
-      {name: :name, type: :string},
-      {name: :slug, type: :slug}
-    ],
+    :name         => {name: :name, type: :string},
     :orig_name    => {name: :original_name, type: :string},
     :marine       => {name: :marine, type: :boolean},
     :rep_m_area   => {name: :reported_marine_area, type: :float},

--- a/test/controllers/protected_areas_controller_test.rb
+++ b/test/controllers/protected_areas_controller_test.rb
@@ -4,11 +4,11 @@ class ProtectedAreasControllerTest < ActionController::TestCase
   def setup
     @region  = FactoryGirl.create(:region, name: 'Killbeurope')
     @country = FactoryGirl.create(:country, name: 'Killbearland', region: @region)
-    @protected_area = FactoryGirl.create(:protected_area, name: 'Killbear', slug: 'killbear', countries: [@country])
+    @protected_area = FactoryGirl.create(:protected_area, name: 'Killbear', countries: [@country])
   end
 
   test '#show returns a 200 HTTP code' do
-    get :show, id: 'killbear'
+    get :show, id: @protected_area.slug
     assert_response :success
   end
 

--- a/test/models/protected_area_test.rb
+++ b/test/models/protected_area_test.rb
@@ -9,7 +9,22 @@ class ProtectedAreaTest < ActiveSupport::TestCase
     assert_equal   "POINT (1.0 1.0)", protected_area.the_geom.to_s
   end
 
-  test '.bounds returns the bounding box for the PA geometry' do
+  test ".save creates a slug attribute consisting of parameterized name
+   and designation" do
+    designation = FactoryGirl.create(:designation, name: 'Protected Area')
+    protected_area = ProtectedArea.create(name: 'Finn and Jake Land', designation: designation)
+
+    assert_equal 'finn-and-jake-land-protected-area', protected_area.slug
+  end
+
+  test ".save creates a slug attribute consisting of parameterized name
+   only, if designation is not set" do
+    protected_area = ProtectedArea.create(name: 'Finn and Jake Land')
+
+    assert_equal 'finn-and-jake-land', protected_area.slug
+  end
+
+  test ".bounds returns the bounding box for the PA geometry" do
     protected_area = FactoryGirl.create(:protected_area, the_geom: 'POLYGON ((-1 0, 0 1, 1 2, 1 0, -1 0))')
 
     assert_equal [[0, -1], [2, 1]], protected_area.bounds

--- a/test/unit/wdpa/attribute_test.rb
+++ b/test/unit/wdpa/attribute_test.rb
@@ -39,11 +39,6 @@ class TestWdpaAttribute < ActiveSupport::TestCase
       "Expected 'abc' to be converted to 0.0"
   end
 
-  test '.standardise converts strings in to slugs' do
-    assert_equal 'walter-white-mountain',
-      Wdpa::Attribute.standardise('Walter White Mountain', as: :slug)
-  end
-
   test ".standardise raises an error if the specified converter doesn't exist" do
     assert_raises NotImplementedError, "No conversion exists for type 'blue'" do
       Wdpa::Attribute.standardise('carebear', as: :blue)

--- a/test/unit/wdpa/data_standard_test.rb
+++ b/test/unit/wdpa/data_standard_test.rb
@@ -277,13 +277,6 @@ class TestWdpaDataStandard < ActiveSupport::TestCase
     assert_equal wkt_geom, the_geom
   end
 
-  test '.attributes_from_standards_hash creates a slug from the PA name' do
-    attributes = Wdpa::DataStandard.attributes_from_standards_hash({name: 'Waltér White Mountain'})
-
-    assert_not_nil attributes[:slug], "Expected the slug to be returned"
-    assert_equal   "walter-white-mountain", attributes[:slug]
-  end
-
   test '.attributes_from_standards_hash ignores attributes not in the
    WDPA Standard' do
     attributes = Wdpa::DataStandard.attributes_from_standards_hash({awesomeness: 'Very Awesome'})


### PR DESCRIPTION
This is because some PAs have the same name, varying only by
designation, which causes obvious issues for our slug URLs :)

Also moves the slug generation to a model method. I think it's better
placed here, and allows us access to all available PA attributes rather
than futzing around in the DataStandard class and sharing data.
