### PR TITLE
Removes close button from Alpha info alert

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -15,14 +15,3 @@
 //= require turbolinks
 //= require cartodb.core
 //= require_tree .
-
-$(document).ready(function() {
-  if (!(/dont-show-alpha-notice/.test(document.cookie))) {
-    $('.alpha-notice').show();
-  }
-
-  $('.alpha-notice .close').on('click', function(event) {
-    $('.alpha-notice').remove();
-    document.cookie = "dont-show-alpha-notice=true";
-  });
-});

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,10 +13,9 @@
 </head>
 <body>
 
-  <div class="alert info alpha-notice" style="display:none;">
+  <div class="alert info">
     <strong>This is an experimental prototype.</strong> There might be errors, inconsistencies, or inaccuracies.
     <a href="#" class="btn-about">About this prototype</a>
-    <span class="close">x</span>
   </div>
 
   <header>


### PR DESCRIPTION
As requested. Users can no longer close the alpha info banner.
