### PR TITLE
Fixing not valid geometries

### DIFF
--- a/docs/statistics.md
+++ b/docs/statistics.md
@@ -71,6 +71,3 @@ We are considering that Russia is in Asia and Turkey is in Europe to
 calculate stats. In the future we may change th DB structure to split
 the protected areas of these two countries and get more acurate values
 for Regional Statistics.
-
-###
-


### PR DESCRIPTION
This pull request was created to overcome the following issues:
- We were ignoring ~800 geometries  that were not valid according postgres
- We were not making geometries valid before intersecting marine pa's with EEZ and TS

After the changes made here we now have a class to repair the geometries right before the countries dissolver:

```
Geospatial::CountryGeometryPopulator.repair 
```

The rake task that calculates stats will always run t.

We have also used the same query (lib/modules/geospatial/templates/repair_geometries.erb) to repair dissolved marine geometries before intersecting with EEZ and TS polygons.
