### PR TITLE
Enables caching on search pages

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,4 +1,6 @@
 class SearchController < ApplicationController
+  after_filter :enable_caching, only: [:index]
+
   def index
     return unless @query = params[:q]
 


### PR DESCRIPTION
Search results do not change between WDPA releases (and the cache is
emptied when releases are imported), so we can actually cache them and
not worry about stale data.
