### PR TITLE
Fix percentage overlap

### DIFF
--- a/app/assets/javascripts/modules/protected_areas/base.js.coffee
+++ b/app/assets/javascripts/modules/protected_areas/base.js.coffee
@@ -57,4 +57,8 @@ $(document).ready( ->
 
     new Tabs($('.js-tabs-network'))
   )
+
+  require(['overlap'], (Overlap) ->
+    new Overlap($('.pa-card'))
+  )
 )

--- a/app/assets/javascripts/modules/protected_areas/overlap.js.coffee
+++ b/app/assets/javascripts/modules/protected_areas/overlap.js.coffee
@@ -1,0 +1,26 @@
+define('overlap', [], ->
+  class Overlap
+    constructor: (@$paCard) ->
+      @addEventListeners()
+
+    addEventListeners: ->
+      klass = @
+      @$paCard.each( (index, elem) ->
+        wdpa_id = $(elem).data('wdpa_id')
+        comparison_wdpa_id = $(elem).find('.reported-area').data('wdpa_id')
+        url = "api/v3/protected_areas/#{wdpa_id}/overlap/#{comparison_wdpa_id}"
+        $.ajax url,
+          type: 'GET'
+          datatype: 'json'
+          success: (data, textStatus, jqXHR) ->
+            klass.populateData(elem, data)
+          error: (jqXHR, textStatus, errorThrown) ->
+            console.log('Something went wrong')
+      )
+
+    populateData: (paCard, data) ->
+      $(paCard).find('.overlap__percentage').html(data.percentage)
+      $(paCard).find('.overlap__sqm-value').html(data.sqm)
+
+  return Overlap
+)

--- a/app/assets/javascripts/protected_areas.js
+++ b/app/assets/javascripts/protected_areas.js
@@ -2,6 +2,7 @@
 //= require 'modules/protected_areas/map_key'
 //= require 'modules/protected_areas/factsheet_handler'
 //= require 'modules/protected_areas/base'
+//= require 'modules/protected_areas/overlap'
 //= require 'modules/fullscreen'
 //= require 'modules/show_hide'
 //= require 'modules/tabs'

--- a/app/controllers/api/v3/protected_areas_controller.rb
+++ b/app/controllers/api/v3/protected_areas_controller.rb
@@ -16,4 +16,12 @@ class Api::V3::ProtectedAreasController < ApplicationController
     protected_area = ProtectedArea.find_by(wdpa_id: params[:id])
     render text: URI.decode(protected_area.geojson)
   end
+
+  def overlap
+    protected_area = ProtectedArea.find_by(wdpa_id: params[:id])
+    comparison_protected_area = ProtectedArea.
+      find_by(wdpa_id: params[:comparison_wdpa_id])
+
+    render json: protected_area.overlap(comparison_protected_area)
+  end
 end

--- a/app/models/protected_area.rb
+++ b/app/models/protected_area.rb
@@ -127,11 +127,11 @@ class ProtectedArea < ActiveRecord::Base
       SELECT
         CASE ST_AREA(a)
           WHEN '0' THEN '0'
-          ELSE ST_AREA(ST_INTERSECTION(a,b))/ST_AREA(a)
+          ELSE ST_AREA(ST_INTERSECTION(ST_MakeValid(a),ST_MakeValid(b)))/ST_AREA(ST_MakeValid(a))
         END AS percentage,
-        ST_AREA(ST_INTERSECTION(a,b)::geography) AS sqm
+        ST_AREA(ST_INTERSECTION(ST_MakeValid(a),ST_MakeValid(b))::geography) AS sqm
       FROM (
-        SELECT pa1.the_geom AS a, pa2.the_geom AS b
+        SELECT ST_SimplifyPreserveTopology(pa1.the_geom, 0.003) AS a, ST_SimplifyPreserveTopology(pa2.the_geom, 0.003) AS b
         FROM protected_areas AS pa1, protected_areas AS pa2
         WHERE pa1.wdpa_id = ? AND pa2.wdpa_id = ?
       ) AS intersection;

--- a/app/models/protected_area.rb
+++ b/app/models/protected_area.rb
@@ -92,14 +92,11 @@ class ProtectedArea < ActiveRecord::Base
     }).results
   end
 
-  def percentage_overlap(pa)
-    percentage = db.execute(percentage_overlap_query(pa)).first["percentage"]
-    (percentage.to_f*100).to_i # WARNING to_i ignores very small percentages of overlap
-  end
-
-  def sqm_overlap(pa)
-    sqm = db.execute(percentage_overlap_query(pa)).first["sqm"]
-    (sqm.to_f / 1000000).round(2)
+  def overlap(pa)
+    overlap = db.execute(overlap_query(pa)).first
+    overlap["percentage"] = (overlap["percentage"].to_f*100).to_i
+    overlap["sqm"] = (overlap["sqm"].to_f / 1000000).round(2)
+    overlap
   end
 
   private
@@ -122,7 +119,7 @@ class ProtectedArea < ActiveRecord::Base
     ])
   end
 
-  def percentage_overlap_query(pa)
+  def overlap_query(pa)
     dirty_query = """
       SELECT
         CASE ST_AREA(a)

--- a/app/views/protected_areas/_pa_card.html.erb
+++ b/app/views/protected_areas/_pa_card.html.erb
@@ -1,4 +1,4 @@
-<div class="pa-card flex-column-3 u-pdf-no-break js-show-hide-target show-hide-target">
+<div class="pa-card flex-column-3 u-pdf-no-break js-show-hide-target show-hide-target" data-wdpa_id=<%= protected_area.wdpa_id %>>
   <h3 class="pa-card__name">
     <%= link_to protected_area.name, protected_area_path(protected_area.wdpa_id) %>
   </h3>
@@ -27,19 +27,21 @@
         <p class="pa-card__detail-value"></p>
       </div>
     </div>
-    <div class="pa-card__detail flex-row u-no-margin">
+    <div class="pa-card__detail flex-row u-no-margin reported-area" data-wdpa_id=<%= comparison_protected_area.wdpa_id %>>
       <div class="pa-card__detail pa-card__detail--inline u-no-margin">
         <p>Reported Area</p>
         <p class="pa-card__detail-value"><%= protected_area.reported_area.round(1) %> km<sup>2</sup></p>
       </div>
       <div class="pa-card__detail pa-card__detail--inline u-no-margin">
         <p>Percentage overlap</p>
-        <p class="pa-card__detail-value">
-          <span class="u-bold">
-            <%= protected_area.percentage_overlap(comparison_protected_area) %>%
+        <p class="pa-card__detail-value overlap">
+          <span class="u-bold overlap__percentage">
           </span>
-          (<%= protected_area.sqm_overlap(comparison_protected_area) %>
-          km<sup>2</sup>)
+          <span class="overlap__sqm">
+            (
+            <span class="overlap__sqm-value"></span>
+            km<sup>2</sup>)
+          </span>
         </p>
       </div>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
       resources :protected_areas, only: [:show] do
         member do
           get 'geojson'
+          get 'overlap/:comparison_wdpa_id', to: 'protected_areas#overlap'
         end
       end
 


### PR DESCRIPTION
Use AJAX to retrieve overlap calculations between PAs.
This helps to load the page quicker and wait for the calculation to be done before populating the PA cards.
I think a spinner would be nice to add for each PA card while waiting for those value.