### PR TITLE
Disallow robots to index our pages to avoid them to slow down pp

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -5,6 +5,7 @@ require File.expand_path('../boot', __FILE__)
 GC::Profiler.enable
 
 require 'rails/all'
+require_relative "../lib/modules/rack_x_robots_tag"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
@@ -23,6 +24,8 @@ module ProtectedPlanet
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
+
+    config.middleware.use Rack::XRobotsTag
 
     config.autoload_paths += %W(#{config.root}/lib/modules #{config.root}/app/presenters)
     config.assets.paths << Rails.root.join('vendor', 'assets', 'bower_components')

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -57,6 +57,8 @@ default: &default
 
   show_pame_statistics: false
 
+  disallow_all_web_crawlers: <%= ENV["DISALLOW_ALL_WEB_CRAWLERS"] %>
+
 development:
   <<: *default
   secret_key_base: c9a5d44fd83941bdf5224c7ddd6da04361df0383bc45cc2e074c2b7ecc47f6730c1b5f53bd627d30182997fed6b80433c9e8040dc7f15d1bac6cbfa0a38c1dfa

--- a/lib/modules/rack_x_robots_tag.rb
+++ b/lib/modules/rack_x_robots_tag.rb
@@ -1,0 +1,17 @@
+module Rack
+  class XRobotsTag
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      status, headers, response = @app.call(env)
+
+      if Rails.application.secrets.disallow_all_web_crawlers.present?
+        headers["X-Robots-Tag"] = "none"
+      end
+
+      [status, headers, response]
+    end
+  end
+end


### PR DESCRIPTION
Adds a value to the header of the response to help preventing robots to index our pages