### PR TITLE
Add links to regions pages from unep regions page

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -42,6 +42,6 @@
 }
 
 .region-link:hover {
-  color: blue;
+  color: #83af46;
   text-decoration: underline;
 }

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -40,3 +40,8 @@
   width: 14rem;
   height: 100%;
 }
+
+.region-link:hover {
+  color: blue;
+  text-decoration: underline;
+}

--- a/app/presenters/region_presenter.rb
+++ b/app/presenters/region_presenter.rb
@@ -48,14 +48,13 @@ class RegionPresenter
   def sources_per_jurisdiction
     sources_per_jurisdiction_hash = {
       international: 0,
-      national: 0
+      national: 0,
+      global: 0
     }
 
     @countries.each do |country|
       country.sources_per_jurisdiction.each do |source_per_jurisdiction|
-        unless source_per_jurisdiction["name"].downcase.to_sym.nil? || source_per_jurisdiction["count"].nil?
-          sources_per_jurisdiction_hash[source_per_jurisdiction["name"].downcase.to_sym] += source_per_jurisdiction["count"].to_i || 0
-        end
+        sources_per_jurisdiction_hash[source_per_jurisdiction["name"].downcase.to_sym] += source_per_jurisdiction["count"].to_i || 0
       end
     end
     sources_per_jurisdiction_hash

--- a/app/presenters/region_presenter.rb
+++ b/app/presenters/region_presenter.rb
@@ -53,7 +53,7 @@ class RegionPresenter
 
     @countries.each do |country|
       country.sources_per_jurisdiction.each do |source_per_jurisdiction|
-        unless source_per_jurisdiction["name"].downcase.to_sym.nil?
+        unless source_per_jurisdiction["name"].downcase.to_sym.nil? || source_per_jurisdiction["count"].nil?
           sources_per_jurisdiction_hash[source_per_jurisdiction["name"].downcase.to_sym] += source_per_jurisdiction["count"].to_i || 0
         end
       end

--- a/app/presenters/region_presenter.rb
+++ b/app/presenters/region_presenter.rb
@@ -53,7 +53,7 @@ class RegionPresenter
 
     @countries.each do |country|
       country.sources_per_jurisdiction.each do |source_per_jurisdiction|
-        unless source_per_jurisdiction["count"].nil?
+        unless source_per_jurisdiction["name"].nil?
           sources_per_jurisdiction_hash[source_per_jurisdiction["name"].downcase.to_sym] += source_per_jurisdiction["count"].to_i || 0
         end
       end

--- a/app/presenters/region_presenter.rb
+++ b/app/presenters/region_presenter.rb
@@ -53,7 +53,7 @@ class RegionPresenter
 
     @countries.each do |country|
       country.sources_per_jurisdiction.each do |source_per_jurisdiction|
-        unless source_per_jurisdiction["name"].nil?
+        unless source_per_jurisdiction["name"].downcase.to_sym.nil?
           sources_per_jurisdiction_hash[source_per_jurisdiction["name"].downcase.to_sym] += source_per_jurisdiction["count"].to_i || 0
         end
       end

--- a/app/presenters/region_presenter.rb
+++ b/app/presenters/region_presenter.rb
@@ -49,7 +49,7 @@ class RegionPresenter
     sources_per_jurisdiction_hash = {
       international: 0,
       national: 0,
-      global: 0
+      regional: 0
     }
 
     @countries.each do |country|

--- a/app/presenters/region_presenter.rb
+++ b/app/presenters/region_presenter.rb
@@ -53,7 +53,9 @@ class RegionPresenter
 
     @countries.each do |country|
       country.sources_per_jurisdiction.each do |source_per_jurisdiction|
-        sources_per_jurisdiction_hash[source_per_jurisdiction["name"].downcase.to_sym] += source_per_jurisdiction["count"].to_i || 0
+        unless source_per_jurisdiction["count"].nil?
+          sources_per_jurisdiction_hash[source_per_jurisdiction["name"].downcase.to_sym] += source_per_jurisdiction["count"].to_i || 0
+        end
       end
     end
     sources_per_jurisdiction_hash

--- a/app/views/cms/_countries_by_regions.html.erb
+++ b/app/views/cms/_countries_by_regions.html.erb
@@ -6,7 +6,7 @@
 <% countries_by_region = Country.pluck(:name, :iso_3, :region_id).group_by { |(name, _, region_id)| regions[region_id] } %>
 
 <% countries_by_region.keys.sort.each do |region| %>
-  <div id="<%= link_to region region_path(Region.find_by(name: region).first.iso) %>" class="row expandable-section js-expandable-section">
+  <div id="<%= link_to region region_path(Region.find_by(name: region).iso) %>" class="row expandable-section js-expandable-section">
     <h3 class="js-trigger expandable-section__header">
       <%= region %><i class="expandable-section__switch js-switch expandable-section__switch is-closed"></i>
     </h3>

--- a/app/views/cms/_countries_by_regions.html.erb
+++ b/app/views/cms/_countries_by_regions.html.erb
@@ -8,7 +8,7 @@
 <% countries_by_region.keys.sort.each do |region| %>
   <div id="<%= region %>" class="row expandable-section js-expandable-section">
     <h3 class="js-trigger expandable-section__header">
-      <%= region %><i class="expandable-section__switch js-switch expandable-section__switch is-closed"></i>
+      <%= link_to region, region_path(Region.find_by(name: region).iso) %><i class="expandable-section__switch js-switch expandable-section__switch is-closed"></i>
     </h3>
     <div class="js-target expandable-section__body u-hide">
       <table class="table js-sortable-table">

--- a/app/views/cms/_countries_by_regions.html.erb
+++ b/app/views/cms/_countries_by_regions.html.erb
@@ -8,7 +8,7 @@
 <% countries_by_region.keys.sort.each do |region| %>
   <div id="<%= region %>" class="row expandable-section js-expandable-section">
     <h3 class="js-trigger expandable-section__header">
-      <%= link_to region region_path(Region.find_by(name: region).iso) %><i class="expandable-section__switch js-switch expandable-section__switch is-closed"></i>
+      <%= region %><i class="expandable-section__switch js-switch expandable-section__switch is-closed"></i>
     </h3>
     <div class="js-target expandable-section__body u-hide">
       <table class="table js-sortable-table">

--- a/app/views/cms/_countries_by_regions.html.erb
+++ b/app/views/cms/_countries_by_regions.html.erb
@@ -6,7 +6,7 @@
 <% countries_by_region = Country.pluck(:name, :iso_3, :region_id).group_by { |(name, _, region_id)| regions[region_id] } %>
 
 <% countries_by_region.keys.sort.each do |region| %>
-  <div id="<%= link_to region region_path(region.iso) %>" class="row expandable-section js-expandable-section">
+  <div id="<%= link_to region region_path(Region.find_by(name: region).first.iso) %>" class="row expandable-section js-expandable-section">
     <h3 class="js-trigger expandable-section__header">
       <%= region %><i class="expandable-section__switch js-switch expandable-section__switch is-closed"></i>
     </h3>

--- a/app/views/cms/_countries_by_regions.html.erb
+++ b/app/views/cms/_countries_by_regions.html.erb
@@ -8,7 +8,8 @@
 <% countries_by_region.keys.sort.each do |region| %>
   <div id="<%= region %>" class="row expandable-section js-expandable-section">
     <h3 class="js-trigger expandable-section__header">
-      <%= link_to region, region_path(Region.find_by(name: region).iso) %><i class="expandable-section__switch js-switch expandable-section__switch is-closed"></i>
+      <%= link_to region, region_path(Region.find_by(name: region).iso), class: 'region-link' %>
+      <i class="expandable-section__switch js-switch expandable-section__switch is-closed"></i>
     </h3>
     <div class="js-target expandable-section__body u-hide">
       <table class="table js-sortable-table">

--- a/app/views/cms/_countries_by_regions.html.erb
+++ b/app/views/cms/_countries_by_regions.html.erb
@@ -6,9 +6,9 @@
 <% countries_by_region = Country.pluck(:name, :iso_3, :region_id).group_by { |(name, _, region_id)| regions[region_id] } %>
 
 <% countries_by_region.keys.sort.each do |region| %>
-  <div id="<%= link_to region region_path(Region.find_by(name: region).iso) %>" class="row expandable-section js-expandable-section">
+  <div id="<%= region %>" class="row expandable-section js-expandable-section">
     <h3 class="js-trigger expandable-section__header">
-      <%= region %><i class="expandable-section__switch js-switch expandable-section__switch is-closed"></i>
+      <%= link_to region region_path(Region.find_by(name: region).iso) %><i class="expandable-section__switch js-switch expandable-section__switch is-closed"></i>
     </h3>
     <div class="js-target expandable-section__body u-hide">
       <table class="table js-sortable-table">

--- a/app/views/cms/_countries_by_regions.html.erb
+++ b/app/views/cms/_countries_by_regions.html.erb
@@ -6,7 +6,7 @@
 <% countries_by_region = Country.pluck(:name, :iso_3, :region_id).group_by { |(name, _, region_id)| regions[region_id] } %>
 
 <% countries_by_region.keys.sort.each do |region| %>
-  <div id="<%= region %>" class="row expandable-section js-expandable-section">
+  <div id="<%= link_to region region_path(region.iso) %>" class="row expandable-section js-expandable-section">
     <h3 class="js-trigger expandable-section__header">
       <%= region %><i class="expandable-section__switch js-switch expandable-section__switch is-closed"></i>
     </h3>


### PR DESCRIPTION
Added links to the regions page from unep-regions page and fixed two issues which appeared on staging;

- The `region.js` was not being precompiled so I had to add that to the config.assets.precompile in application.rb,
-  A minor adjustment to add `regional` to the `sources_per_jurisdiction_hash` to fix bug.