### PR TITLE
Fix blog results

### DIFF
--- a/app/helpers/cms_helper.rb
+++ b/app/helpers/cms_helper.rb
@@ -60,6 +60,8 @@ module CmsHelper
   end
 
   def get_filtered_pages pages
+    pages.select {|page| page['is_published'] = true }
+
     if params[:year]
       pages = pages.where("date_part('year', created_at) = ?", params[:year])
 

--- a/app/helpers/cms_helper.rb
+++ b/app/helpers/cms_helper.rb
@@ -60,13 +60,11 @@ module CmsHelper
   end
 
   def get_filtered_pages pages
-    pages.select {|page| page['is_published'] = true }
-
     if params[:year]
-      pages = pages.where("date_part('year', created_at) = ?", params[:year])
+      pages = pages.select{|page| page['created_at'].year == params[:year].to_i}
 
       if params[:month]
-        pages = pages.where("date_part('month', created_at) = ?", params[:month])
+        pages = pages.select{|page| page['created_at'].month == params[:month].to_i}
       end
     else
       pages

--- a/app/presenters/cms_presenter.rb
+++ b/app/presenters/cms_presenter.rb
@@ -18,8 +18,8 @@ class CmsPresenter
     resources.sort_by(&:created_at).map(&:created_at).group_by(&:year)
   end
 
-  def self.all_by_month resources, year
-    resources.where("date_part('year', created_at) = ?", year).group_by{|u| u.created_at.strftime('%B-%m')}
+  def self.all_by_month pages, year
+    pages.select{|page| page['created_at'].year == year}.group_by{|u| u.created_at.strftime('%B-%m')}
   end
 
   private

--- a/app/views/cms/_children_nav.html.erb
+++ b/app/views/cms/_children_nav.html.erb
@@ -1,5 +1,5 @@
 <div class="vertical-nav">
-  <% @cms_page.children.each do |page| %>
+  <% @cms_page.children.published.each do |page| %>
     
     <% if page.slug[0,3] == 'URL' %>
       <%= link_to 'http://' + page.slug[3..-1], title: 'Visit ' + page.label, target: '_blank', class: 'vertical-nav__element' do %>

--- a/app/views/cms/_siblings_nav.html.erb
+++ b/app/views/cms/_siblings_nav.html.erb
@@ -1,5 +1,5 @@
 <div class="vertical-nav">
-  <% @cms_page.parent.children.each do |page| %>
+  <% @cms_page.parent.children.published.each do |page| %>
     <%= cms_page page, @cms_page %>
   <% end %>
 </div>

--- a/app/views/cms/blog/_index.html.erb
+++ b/app/views/cms/blog/_index.html.erb
@@ -1,3 +1,5 @@
+<% @posts = @cms_page.descendants.select {|page| page['is_published'] == true } %>
+
 <main class="container--profile container--right-padded container--push-bottom">
   <nav class="breadcrumbs">
     <%= render partial: "cms/breadcrumbs" %>  
@@ -7,13 +9,13 @@
     <h1 class="hero__title hero__title--article">Blog</h1>
   </div>
   
-  <%= render partial: "cms/blog/filter_bar", locals: { posts: @cms_page.children } %>
+  <%= render partial: "cms/blog/filter_bar", locals: { posts: @posts } %>
 
   <div class="three-fourths">
-    <p class="header-with-delimiter header-with-delimiter--smaller header-with-delimiter--bold">Showing <%= get_filtered_pages(@cms_page.children).size %> blog post(s).</p>
+    <p class="header-with-delimiter header-with-delimiter--smaller header-with-delimiter--bold">Showing <%= get_filtered_pages(@posts).size %> blog post(s).</p>
 
     <div class="right-padded">
-      <%= render partial: 'cms/blog/blog_post', collection: get_filtered_pages(@cms_page.children) %>
+      <%= render partial: 'cms/blog/blog_post', collection: get_filtered_pages(@posts) %>
     </div>
   </div>
 </main>

--- a/app/views/marine/sections/_coverage_map.html.erb
+++ b/app/views/marine/sections/_coverage_map.html.erb
@@ -1,4 +1,4 @@
-<h2 class="header--h2-insights container--profile">Protected areas coverage in 2018</h2>
+<h2 class="header--h2-insights container--profile">Protected areas coverage in <%= Date.today.year %></h2>
 
 <div class="u-relative">
   <div


### PR DESCRIPTION
- Make sure that all blog posts are listed in on the Blog page (not just the direct children of the Blog page) - this returns an array of hashes instead of a hash
- Fix up year/month filter to work with an array of hashes
- Fix up the sibling and child templates so that they only show published pages
- Make year on the marine page dynamic