### PR TITLE
Hidden evaluations are as such when PA is missing and restricted is f…

### DIFF
--- a/lib/modules/wdpa/pame_importer.rb
+++ b/lib/modules/wdpa/pame_importer.rb
@@ -67,7 +67,7 @@ module Wdpa::PameImporter
         pe.assessment_is_public = assessment_is_public
       end
       if protected_area.nil?
-        hidden_evaluations << wdpa_id
+        hidden_evaluations << wdpa_id unless restricted
         countries = []
         iso3s.split(",").each do |iso3|
           country = Country.find_by(iso_3: iso3)

--- a/lib/modules/wdpa/pame_importer.rb
+++ b/lib/modules/wdpa/pame_importer.rb
@@ -68,7 +68,6 @@ module Wdpa::PameImporter
       end
       if protected_area.nil?
         hidden_evaluations << wdpa_id unless restricted
-        countries = []
         iso3s.split(",").each do |iso3|
           country = Country.find_by(iso_3: iso3)
           if country.present?


### PR DESCRIPTION
## Description

A Pame Evaluation should be hidden when the PA is missing from the database (even though the wdpaid is given in the CSV) and when the restricted flag is `false`.

For the sake of clarity:

```
PA present && restricted false = show evaluation
PA not present && restricted true = show evaluation as restricted
PA not present && restricted false = do not show
```

⚠️  ## Work still to do before merging ⚠️ 

The currrent PAME CSV is incorrect. There's a `country` column instead of the `iso3` column with the full name of the country. That needs to be reverted back to be iso codes. This is causing the PameImporter to fail fetching the countries when a PA is missing from the db.

The PAME repo would probably require some changes as well.
