### PR TITLE
Rationalised the index interface

### DIFF
--- a/test/integration/search_page_test.rb
+++ b/test/integration/search_page_test.rb
@@ -12,9 +12,10 @@ class SearchPageTest < ActionDispatch::IntegrationTest
     pa = FactoryGirl.create(:protected_area, name: "skdfhshdf", countries: [country], marine: false, has_parcc_info: false, is_green_list: false, has_irreplaceability_info: false)
 
     @psi = Search::Index.new Search::PA_INDEX, ProtectedArea.all
+    @psi.create
     @csi = Search::Index.new Search::COUNTRY_INDEX, Country.without_geometry.all
-
-
+    @csi.create
+    
   end
 
   def teardown

--- a/test/integration/search_test.rb
+++ b/test/integration/search_test.rb
@@ -7,7 +7,9 @@ class SearchTest < ActionDispatch::IntegrationTest
     # ES and WebMock don't get along
     WebMock.disable!
     @psi = Search::Index.new Search::PA_INDEX, ProtectedArea.all
+    @psi.create
     @csi = Search::Index.new Search::COUNTRY_INDEX, Country.without_geometry.all
+    @csi.create
   end
 
   def teardown


### PR DESCRIPTION
the static methods now act on both indexes and don't take an
index_name as an argument. The object methods act on a single index
and the index_name is assigned on construction. new and create are
separated out so the flow goes new -> create -> index and then its
ready for search, then can cleanup with delete