### PR TITLE
Use latest unepwcmc-geospatial-base image with phantomjs support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
-FROM unepwcmc/unepwcmc-geospatial-base:latest
+FROM unepwcmc/unepwcmc-geospatial-base:20190809
 LABEL maintainer="andrew.potter@unep-wcmc.org"
 
 USER unepwcmc
-
 
 WORKDIR /ProtectedPlanet
 ADD Gemfile /ProtectedPlanet/Gemfile
@@ -14,8 +13,6 @@ COPY --chown=unepwcmc:unepwcmc . /ProtectedPlanet
 
 RUN /bin/bash -l -c "bundle install"
 RUN /bin/bash -l -c "yarn install"
-
-
 
 EXPOSE 3000
 


### PR DESCRIPTION
This is the initial work to add phantomjs via the newly updated `unepwcmc-geospatial-base` docker image. 

You can find phantomjs at `/usr/bin/phantomjs`

Please remember to run `docker-compose build` before `docker-compose up` to see this change. It will take a few minutes to rebuild.
