### PR TITLE
T11 save global stats

### DIFF
--- a/app/controllers/target_dashboard_controller.rb
+++ b/app/controllers/target_dashboard_controller.rb
@@ -3,8 +3,7 @@ class TargetDashboardController < ApplicationController
   def index
     countries = Country.paginate(per_page: CountrySerializer::PER_PAGE, page: 1)
     @countries = CountrySerializer.new({}, countries).serialize
-    @targets = Aichi11TargetSerializer.new.serialize
-    @global_stats = Aichi11Target.get_global_stats
+    @global_stats = Aichi11TargetSerializer.new.serialize
 
     _options = Aichi11TargetDashboardSerializer.new.serialize_options
 

--- a/app/models/aichi11_target.rb
+++ b/app/models/aichi11_target.rb
@@ -1,6 +1,12 @@
 class Aichi11Target < ActiveRecord::Base
   validates_inclusion_of :singleton_guard, :in => [0]
 
+  ATTRIBUTES = {
+    representative: 'Representative',
+    well_connected: 'Well connected',
+    importance: 'Areas of importance for biodiversity'
+  }.freeze
+
   def self.instance
     first || import
   end
@@ -16,46 +22,6 @@ class Aichi11Target < ActiveRecord::Base
     obj.update_attributes(Stats::CountryStatisticsApi.global_stats_for_import)
   end
 
-  ATTRIBUTES = {
-    representative: 'Representative',
-    well_connected: 'Well connected',
-    importance: 'Areas of importance for biodiversity'
-  }.freeze
-  TERRESTRIAL = {
-    title: 'Terrestrial',
-    colour: 'terrestrial'
-  }.freeze
-  MARINE = {
-    title: 'Marine',
-    colour: 'marine'
-  }.freeze
-  # Global by default for both national and global stats
-  # as the API stats are not currently split between marine and terrestrial
-  DEFAULT_CHART_JSON = {
-    title: 'Global',
-    colour: 'global',
-    value: nil,
-    target: nil
-  }.freeze
-  def self.get_global_stats
-    # Get global stats saved in this db table and format accordingly
-    global_stats = ATTRIBUTES.keys.map do |attr_name|
-      format_data(attr_name) do
-        instance.public_send("#{attr_name}_global_value")
-      end
-    end
-
-    pp_global_stats = []
-    stats.each do |name, attributes|
-      json = { id: attributes[:slug], title: attributes[:name], charts: [] }
-      terrestrial_chart = DEFAULT_CHART_JSON.merge(**TERRESTRIAL, **attributes[:terrestrial])
-      marine_chart = DEFAULT_CHART_JSON.merge(**MARINE, **attributes[:marine])
-      json[:charts] = [terrestrial_chart, marine_chart]
-      pp_global_stats << json.dup
-    end
-    global_stats.unshift(*pp_global_stats)
-  end
-
   def self.import
     # Import representative, well_connected and importance values from API
     global_values = Stats::CountryStatisticsApi.global_stats_for_import
@@ -69,52 +35,5 @@ class Aichi11Target < ActiveRecord::Base
     Rails.root.join('lib/data/seeds/aichi11_targets.csv')
   end
 
-  def self.stats
-    {
-      coverage: {
-        name: 'Coverage',
-        slug: 'coverage',
-        terrestrial: {
-          value: CountryStatistic.global_percentage_pa_land_cover,
-          target: instance.coverage_terrestrial
-        },
-        marine: {
-          value: CountryStatistic.global_percentage_pa_marine_cover,
-          target: instance.coverage_marine
-        }
-      },
-      effectively_managed: {
-        name: 'Effectively managed',
-        slug: 'effectively_managed',
-        terrestrial: {
-          value: PameStatistic.global_pame_percentage_pa_land_cover,
-          target: instance.effectively_managed_terrestrial
-        },
-        marine: {
-          value: PameStatistic.global_pame_percentage_pa_marine_cover,
-          target: instance.effectively_managed_marine
-        }
-      }
-    }
-  end
-
-  # This is only used for global stats
-  # It's a shared method between this model and the API module
-  # The value is fetched from the db if used here,
-  # otherwise it is fetched from the API
-  def self.format_data(endpoint)
-    json = {
-      id: endpoint,
-      title: ATTRIBUTES[endpoint.to_sym],
-      charts: []
-    }
-    chart_json = DEFAULT_CHART_JSON.dup
-
-    value = yield
-    target = instance.public_send("#{endpoint.to_s}_global")
-    json[:charts] << chart_json.merge!({ value: value, target: target })
-    json
-  end
-
-  private_class_method :import, :aichi11_target_csv_path, :stats
+  private_class_method :import, :aichi11_target_csv_path
 end

--- a/app/serializers/aichi11_target_serializer.rb
+++ b/app/serializers/aichi11_target_serializer.rb
@@ -1,33 +1,94 @@
-class Aichi11TargetSerializer < BaseSerializer
-  PER_PAGE = 1.freeze
+class Aichi11TargetSerializer
+  TERRESTRIAL = {
+    title: 'Terrestrial',
+    colour: 'terrestrial'
+  }.freeze
+  MARINE = {
+    title: 'Marine',
+    colour: 'marine'
+  }.freeze
+  # Global by default for both national and global stats
+  # as the API stats are not currently split between marine and terrestrial
+  DEFAULT_CHART_JSON = {
+    title: 'Global',
+    colour: 'global',
+    value: nil,
+    target: nil
+  }.freeze
 
-  def initialize(params={}, data=nil)
-    super(Aichi11Target, params, data)
+  def initialize
+    @model = Aichi11Target
   end
 
   def serialize
-    super
+    # Get global stats saved in this db table and format accordingly
+    global_stats = @model::ATTRIBUTES.keys.map do |attr_name|
+      format_data(attr_name) do
+        instance.public_send("#{attr_name}_global_value")
+      end
+    end
+
+    pp_global_stats = []
+    stats.each do |name, attributes|
+      json = { id: attributes[:slug], title: attributes[:name], charts: [] }
+      terrestrial_chart = DEFAULT_CHART_JSON.merge(**TERRESTRIAL, **attributes[:terrestrial])
+      marine_chart = DEFAULT_CHART_JSON.merge(**MARINE, **attributes[:marine])
+      json[:charts] = [terrestrial_chart, marine_chart]
+      pp_global_stats << json.dup
+    end
+    global_stats.unshift(*pp_global_stats)
   end
-  
+
+  # This is only used for global stats
+  # It's a shared method between this model and the API module
+  # The value is fetched from the db if used here,
+  # otherwise it is fetched from the API
+  def format_data(endpoint)
+    json = {
+      id: endpoint,
+      title: @model::ATTRIBUTES[endpoint.to_sym],
+      charts: []
+    }
+    chart_json = DEFAULT_CHART_JSON.dup
+
+    value = yield
+    target = instance.public_send("#{endpoint.to_s}_global")
+    json[:charts] << chart_json.merge!({ value: value, target: target })
+    json
+  end
+
   private
 
-  def fields
-    @model.column_names.reject do |attr|
-      ['id', 'singleton_guard', 'created_at', 'updated_at'].include?(attr)
-    end.map(&:to_sym)
+  def stats
+    {
+      coverage: {
+        name: 'Coverage',
+        slug: 'coverage',
+        terrestrial: {
+          value: CountryStatistic.global_percentage_pa_land_cover,
+          target: instance.coverage_terrestrial
+        },
+        marine: {
+          value: CountryStatistic.global_percentage_pa_marine_cover,
+          target: instance.coverage_marine
+        }
+      },
+      effectively_managed: {
+        name: 'Effectively managed',
+        slug: 'effectively_managed',
+        terrestrial: {
+          value: PameStatistic.global_pame_percentage_pa_land_cover,
+          target: instance.effectively_managed_terrestrial
+        },
+        marine: {
+          value: PameStatistic.global_pame_percentage_pa_marine_cover,
+          target: instance.effectively_managed_marine
+        }
+      }
+    }
   end
 
-  def sort_by
-    # This is only necessary to avoid an exception being thrown.
-    # As there's only one record, sorting is not really necessary.
-    super || 'coverage_marine'
-  end
-
-  def order
-    super || 'desc'
-  end
-
-  def per_page_default
-    PER_PAGE
+  def instance
+    @instance ||= @model.instance
   end
 end

--- a/lib/modules/stats/country_statistics_api.rb
+++ b/lib/modules/stats/country_statistics_api.rb
@@ -93,7 +93,7 @@ module Stats::CountryStatisticsApi
     end
 
     def format_data(data, endpoint)
-      Aichi11Target.format_data(endpoint) do
+      Aichi11TargetSerializer.new.format_data(endpoint) do
         calculate_value(data, endpoint)
       end
     end


### PR DESCRIPTION
## Description

This saves stats fetched from the API into the Aichi11Target table related to:
* importance
* well connected
* representative

This also results in a faster initial page load.

## Notes

⚠️ `bundle exec rake db:migrate` required from [this branch]/PR(https://github.com/unepwcmc/protectedplanet-db/pull/22)
⚠️ Please read notes on that db PR as well.

Related ticket: [Initial page load - Global stats](https://unep-wcmc.codebasehq.com/projects/pp-target-11-dashboard/tickets/39)