### PR TITLE
T11 adjust global stats

### DIFF
--- a/app/models/pame_statistic.rb
+++ b/app/models/pame_statistic.rb
@@ -7,7 +7,7 @@ class PameStatistic < ApplicationRecord
       Stats::Global.calculate_stats_for(self, field_name)
     end
 
-    total_area = CountryStatistic.public_send("global_pa_#{type}_area")
+    total_area = CountryStatistic.public_send("global_#{type}_area")
     define_singleton_method("global_pame_percentage_pa_#{type}_cover") do
       (public_send("global_#{field_name}") / total_area * 100).round(2)
     end

--- a/lib/modules/stats/global.rb
+++ b/lib/modules/stats/global.rb
@@ -36,6 +36,8 @@ class Stats::Global
   end
 
   def self.calculate_stats_for(klass, field_name)
+    # Statistics with no country id belong to ABNJ and ATA
+    # which should be included in the global stat calculation
     stats = klass.all
     stats.map(&field_name.to_sym).inject(0) do |_sum, x|
       _sum + (x || 0)

--- a/lib/modules/stats/global.rb
+++ b/lib/modules/stats/global.rb
@@ -36,11 +36,9 @@ class Stats::Global
   end
 
   def self.calculate_stats_for(klass, field_name)
-    stats = klass.where.not(country_id: nil)
-    sum =
-      stats.map(&field_name.to_sym).inject(0) do |_sum, x|
-        _sum + (x || 0)
-      end
-    (sum / Country.count).round(2)
+    stats = klass.all
+    stats.map(&field_name.to_sym).inject(0) do |_sum, x|
+      _sum + (x || 0)
+    end
   end
 end


### PR DESCRIPTION
## Description

A small fix to include ABNJ (Area Beyond National Jurisdiction) and ATA (Antarctica) in the global stats calculations.
Statistics objects with `nil` country_id are referring to those particular areas.

Also make sure to calculate global Pame stats correctly.