### PR TITLE
Fix wdpa import  after upgrade aws-sdk gem from v1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'rails', '5.0.5'
 gem 'webpacker', '~> 4.0.2'
 
 gem 'pg', '~> 0.21'
-gem 'activerecord-postgis-adapter', '~> 4.0.0'
+gem 'activerecord-postgis-adapter', '4.1.0'
 gem 'dbf', '~> 2.0.7'
 #
 gem 'elasticsearch', '~> 7.2.0'
@@ -74,6 +74,7 @@ group :test, :development do
   gem 'byebug', '~> 9.0', '>= 9.0.5'
 
 end
+
 
 
 gem 'will_paginate', '~> 3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,9 +43,9 @@ GEM
       activemodel (= 5.0.5)
       activesupport (= 5.0.5)
       arel (~> 7.0)
-    activerecord-postgis-adapter (4.0.5)
+    activerecord-postgis-adapter (4.1.0)
       activerecord (~> 5.0.0)
-      rgeo-activerecord (~> 5.0.0)
+      rgeo-activerecord (~> 6.0)
     activesupport (5.0.5)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
@@ -1010,10 +1010,10 @@ GEM
     responders (3.0.0)
       actionpack (>= 5.0)
       railties (>= 5.0)
-    rgeo (0.6.0)
-    rgeo-activerecord (5.0.1)
-      activerecord (~> 5.0.0)
-      rgeo (~> 0.3)
+    rgeo (2.1.1)
+    rgeo-activerecord (6.2.1)
+      activerecord (>= 5.0)
+      rgeo (>= 1.0.0)
     ruby_parser (3.13.0)
       sexp_processor (~> 4.9)
     rubyzip (1.2.2)
@@ -1114,7 +1114,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activerecord-postgis-adapter (~> 4.0.0)
+  activerecord-postgis-adapter (= 4.1.0)
   appsignal (~> 1.3.6)
   autoprefixer-rails
   aws-sdk (= 3.0.1)

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,13 +1,13 @@
 set :stage, :production
+set :branch, "new_production_deploy"
 
-server "web-production-linode.protectedplanet.net", user: 'wcmc', roles: %w{web}
-server "import-production-linode.protectedplanet.net", user: 'wcmc', roles: %w{util}
-server "db-production-linode.protectedplanet.net", user: 'wcmc', roles: %w{db}, :no_release => true
+server 'new-web.pp-production.linode.protectedplanet.net', user: 'wcmc', roles: %w{web app db}
 
 set :application, "protectedplanet"
-set :server_name, "web-production-linode.protectedplanet.net"
+set :server_name, "protectedplanet"
 set :sudo_user, "wcmc"
 set :app_port, "80"
+
 
 
 # server-based syntax

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,5 +1,4 @@
 set :stage, :production
-set :branch, "new_production_deploy"
 
 server 'new-web.pp-production.linode.protectedplanet.net', user: 'wcmc', roles: %w{web app db}
 

--- a/config/sidekiq-import.yml
+++ b/config/sidekiq-import.yml
@@ -1,0 +1,8 @@
+---
+:concurrency: 5
+production:
+  :concurrency: 25
+staging:
+  :concurrency: 25
+:queues:
+  - import

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -4,3 +4,6 @@ production:
   :concurrency: 25
 staging:
   :concurrency: 25
+:queues:
+  - default
+

--- a/lib/modules/countries_geometry_importer.rb
+++ b/lib/modules/countries_geometry_importer.rb
@@ -33,14 +33,16 @@ class CountriesGeometryImporter
   end
 
   def download
-    compressed_geometries.get(response_target: FILEPATH)
+    File.open(FILEPATH, 'w:ASCII-8BIT') do |file|
+      file.write compressed_geometries
+    end
   end
 
   def compressed_geometries
     bucket_name = Rails.application.secrets.aws_datasets_bucket
     filename = File.basename(FILEPATH)
 
-    @s3.buckets[bucket_name].objects[filename]
+    @s3.buckets[bucket_name].objects[filename].read
   end
 
   def restore_to_temporary_table

--- a/lib/modules/countries_geometry_importer.rb
+++ b/lib/modules/countries_geometry_importer.rb
@@ -33,16 +33,14 @@ class CountriesGeometryImporter
   end
 
   def download
-    File.open(FILEPATH, 'w:ASCII-8BIT') do |file|
-      file.write compressed_geometries
-    end
+    compressed_geometries.get(response_target: FILEPATH)
   end
 
   def compressed_geometries
     bucket_name = Rails.application.secrets.aws_datasets_bucket
     filename = File.basename(FILEPATH)
 
-    @s3.buckets[bucket_name].objects[filename].read
+    @s3.buckets[bucket_name].objects[filename]
   end
 
   def restore_to_temporary_table

--- a/lib/modules/s3.rb
+++ b/lib/modules/s3.rb
@@ -44,8 +44,10 @@ class S3
 
   def delete_all path
     bucket = @s3.bucket(Rails.application.secrets.aws_downloads_bucket)
-    objects = bucket.objects.with_prefix(path)
+    objects = bucket.objects(prefix: path)
 
-    objects.delete_all
+    objects.each do |objs|
+      objs.object.delete
+    end
   end
 end

--- a/lib/modules/wdpa/s3.rb
+++ b/lib/modules/wdpa/s3.rb
@@ -20,7 +20,7 @@ class Wdpa::S3
   end
 
   def download_current_wdpa_to filename
-    current_wdpa.get(response_target: filename)
+    current_wdpa.get(response_target: filename, response_content_encoding: 'ASCII_8BIT')
   end
 
   def new_wdpa? since

--- a/lib/modules/wdpa/s3.rb
+++ b/lib/modules/wdpa/s3.rb
@@ -20,9 +20,7 @@ class Wdpa::S3
   end
 
   def download_current_wdpa_to filename
-    File.open(filename, 'w:ASCII-8BIT') do |file|
-      file.write current_wdpa.get
-    end
+    current_wdpa.get(response_target: filename)
   end
 
   def new_wdpa? since
@@ -37,7 +35,7 @@ class Wdpa::S3
   private
 
   def current_wdpa
-    available_wdpa_databases.sort_by(&:last_modified).last
+    available_wdpa_databases.sort_by(&:last_modified).last.object
   end
 
   def available_wdpa_databases

--- a/lib/modules/wdpa/s3.rb
+++ b/lib/modules/wdpa/s3.rb
@@ -21,7 +21,7 @@ class Wdpa::S3
 
   def download_current_wdpa_to filename
     File.open(filename, 'w:ASCII-8BIT') do |file|
-      file.write current_wdpa.read
+      file.write current_wdpa.get
     end
   end
 

--- a/test/unit/wdpa/s3_test.rb
+++ b/test/unit/wdpa/s3_test.rb
@@ -27,23 +27,23 @@ class TestWdpaS3Downloader < ActiveSupport::TestCase
     file_contents = "\x9B".force_encoding(Encoding::ASCII_8BIT)
 
     latest_file_mock = mock()
+    latest_file_mock.stubs(:object).returns(latest_file_mock)
     latest_file_mock.stubs(:last_modified).returns(2.days.ago)
-    latest_file_mock.expects(:read).returns(file_contents)
+    latest_file_mock.expects(:get).returns(file_contents)
 
     @bucket_mock.stubs(:objects).returns([latest_file_mock])
     Aws::S3::Resource.stubs(:new).returns(@s3_mock)
 
     Wdpa::S3.download_current_wdpa_to filename
-    File.delete filename
   end
 
   test '.download_current_wdpa_to retrieves the latest WDPA from S3, and saves it to the
    given filename' do
     filename = 'hey_this_is_a_filename.zip'
-
     latest_file_mock = mock()
+    latest_file_mock.stubs(:object).returns(latest_file_mock)
     latest_file_mock.stubs(:last_modified).returns(2.days.ago)
-    latest_file_mock.expects(:read).returns("")
+    latest_file_mock.expects(:get).returns("")
 
     oldest_file_mock = mock()
     oldest_file_mock.stubs(:last_modified).returns(10.days.ago)
@@ -55,13 +55,6 @@ class TestWdpaS3Downloader < ActiveSupport::TestCase
     ])
 
     Aws::S3::Resource.stubs(:new).returns(@s3_mock)
-
-    file_write_mock = mock()
-    file_write_mock.stubs(:write)
-
-    File.expects(:open).
-      with(filename, 'w:ASCII-8BIT').
-      yields(file_write_mock)
 
     Wdpa::S3.download_current_wdpa_to filename
   end


### PR DESCRIPTION
This is to fix the WDPA import process after the overall upgrade of the code.
I have tested this on the new production server only and seems working fine but please double check if you notice something odd http://pp.new-web.pp-production.linode.protectedplanet.net/

:warning:  Be aware that this includes the branch `new_production_deploy` where the gem activerecord-postgis-adapter has been updated to fix the issue with the search by country.
Furthermore, the capistrano deploy files point to the new server (staging and production).
 