### PR TITLE
Fix sorting for coverage and effectively_managed

### DIFF
--- a/app/helpers/target_dashboard_helper.rb
+++ b/app/helpers/target_dashboard_helper.rb
@@ -1,6 +1,6 @@
 module TargetDashboardHelper
   def getTooltipText id
-    tooltip = t("thematic_area.target_11_dashboard.tooltips").select { |_tooltip| _tooltip[:id] == id }.first
+    tooltip = t("thematic_area.target_11_dashboard.tooltips").select { |_tooltip| _tooltip[:id] == id.to_s }.first
 
     tooltip ? tooltip[:text] : ''
   end

--- a/app/serializers/aichi11_target_dashboard_serializer.rb
+++ b/app/serializers/aichi11_target_dashboard_serializer.rb
@@ -89,7 +89,10 @@ class Aichi11TargetDashboardSerializer < CountrySerializer
     _data = ActiveRecord::Base.connection.execute(query)
 
     if @params[:sort_by].present?
-      _data = _data.sort_by { |d| d[sort_by] }
+      sort_terms = sort_by.split('+')
+      _data = _data.sort_by do |d|
+        sort_terms.inject(0) { |sum, x| sum + (d[x] || 0) }
+      end
       order.downcase == 'desc'? _data.reverse : _data
     else
       _data.to_a
@@ -107,9 +110,9 @@ class Aichi11TargetDashboardSerializer < CountrySerializer
     sort_field_marine = 'percentage_pa_marine_cover'
     case _sort_by
     when 'coverage'
-      "(#{sort_field_land} + #{sort_field_marine})"
+      "#{sort_field_land}+#{sort_field_marine}"
     when 'effectively_managed'
-      "(pame_#{sort_field_land} + pame_#{sort_field_marine})"
+      "pame_#{sort_field_land}+pame_#{sort_field_marine}"
     else
       if _sort_by.present? && STATS[_sort_by.to_sym].present?
         STATS[_sort_by.to_sym][:column_name]

--- a/app/serializers/aichi11_target_dashboard_serializer.rb
+++ b/app/serializers/aichi11_target_dashboard_serializer.rb
@@ -91,7 +91,7 @@ class Aichi11TargetDashboardSerializer < CountrySerializer
     if @params[:sort_by].present?
       sort_terms = sort_by.split('+')
       _data = _data.sort_by do |d|
-        sort_terms.inject(0) { |sum, x| sum + (d[x] || 0) }
+        sort_terms.inject(0.0) { |sum, x| sum + (d[x].to_f || 0.0) }
       end
       order.downcase == 'desc'? _data.reverse : _data
     else

--- a/app/serializers/aichi11_target_dashboard_serializer.rb
+++ b/app/serializers/aichi11_target_dashboard_serializer.rb
@@ -91,7 +91,11 @@ class Aichi11TargetDashboardSerializer < CountrySerializer
     if @params[:sort_by].present?
       sort_terms = sort_by.split('+')
       _data = _data.sort_by do |d|
-        sort_terms.inject(0.0) { |sum, x| sum + (d[x].to_f || 0.0) }
+        if sort_terms.length > 1
+          sort_terms.inject(0.0) { |sum, x| sum + (d[x] || 0.0) }
+        else
+          d[sort_terms.first]
+        end
       end
       order.downcase == 'desc'? _data.reverse : _data
     else


### PR DESCRIPTION
## Description

Fix sorting not working for coverage and effectively managed.
This was happening because the wrong key was being passed to the hash of each record to fetch the values.