### PR TITLE
Import assessments in PameStatistic

### DIFF
--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -26,6 +26,14 @@ class Country < ApplicationRecord
     country_statistic
   end
 
+  def assessments
+    pame_evaluations.count
+  end
+
+  def assessed_pas
+    pame_evaluations.map(&:wdpa_id).uniq.count
+  end
+
   def protected_areas_with_iucn_categories
     valid_categories = "'Ia', 'Ib', 'II', 'II', 'IV', 'V', 'VI'"
     iucn_categories.where(

--- a/lib/modules/stats/country_statistics_importer.rb
+++ b/lib/modules/stats/country_statistics_importer.rb
@@ -17,12 +17,25 @@ module Stats::CountryStatisticsImporter
 
     CSV.foreach(path, headers: true) do |row|
       country_iso3 = row.delete('iso3').last
+      country_id = countries[country_iso3]
       # If the value is na (not applicable) use nil
       row.each { |key, value| row[key] = nil if value && value.downcase == 'na' }
-      attrs = {country_id: countries[country_iso3]}.merge(row)
+      attrs = {country_id: country_id}.merge(row)
+      attrs = attrs.merge(pame_assessments(country_id)) if model == PameStatistic
 
       model.create(attrs)
     end
+  end
+
+  def self.pame_assessments(country_id)
+    return {} unless country_id
+
+    country = Country.find(country_id)
+
+    {
+      assessments: country.assessments,
+      assessed_pas: country.assessed_pas
+    }
   end
 
   def self.stats_csv_path


### PR DESCRIPTION
## Description

Changes necessary for having `assessments` and `assessed_pas` populated within the PameStatistic model.
These changes are useful for [this API PR](https://github.com/unepwcmc/protectedplanet-api/pull/15) while we follow up on having those figures within the provided CSV file.

# Notes
To test this locally and on staging you need to perform the following in the rails console:

```
> ImportTools.statistics_monthly_import
```