### PR TITLE
Fix countries assessments count mismatch

### DIFF
--- a/lib/modules/wdpa/pame_importer.rb
+++ b/lib/modules/wdpa/pame_importer.rb
@@ -68,11 +68,12 @@ module Wdpa::PameImporter
       end
       if protected_area.nil?
         hidden_evaluations << wdpa_id unless restricted
-        iso3s.split(",").each do |iso3|
-          country = Country.find_by(iso_3: iso3)
-          if country.present?
-            pame_evaluation.countries << country unless pame_evaluation.countries.include? country
-          end
+      end
+
+      iso3s.split(",").each do |iso3|
+        country = Country.find_by(iso_3: iso3)
+        if country.present?
+          pame_evaluation.countries << country unless pame_evaluation.countries.include? country
         end
       end
     end


### PR DESCRIPTION
## Description

Add country association regardless of wdpaid being present.
[Ticket](https://unep-wcmc.codebasehq.com/projects/protected-planet-support-and-maintenance/tickets/116)

## Notes

`Wdpa::PameImporter.import` and then `ImportTools.statistics_monthly_import` are required to apply the fix to the db.