### PR TITLE
ActiveStorage raises an error 500 on File Not Found.

### DIFF
--- a/config/initializers/active_storage_file_not_found_fix.rb
+++ b/config/initializers/active_storage_file_not_found_fix.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# ActiveStorage raises an error 500 on File Not Found.
+# To fix this, we will catch when it occurs and return a more FE-friendly
+# response.
+Rails.application.config.after_initialize do
+  ::ActiveStorage::DiskController.class_eval do
+    rescue_from Errno::ENOENT do
+      head :not_found
+    end
+  end
+  ::ActiveStorage::RepresentationsController.class_eval do
+    rescue_from Errno::ENOENT do
+      head :not_found
+    end
+  end
+end


### PR DESCRIPTION
ActiveStorage raises an error 500 on File Not Found.
To fix this, we will catch when it occurs and return a more FE-friendly response.


Output from console on `http://localhost:3000/en/thematical-areas/global-partnership-on-aichi-target-11`
```
VM60:1 GET http://localhost:3000/rails/active_storage/disk/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaDFrVW5OSVZGbExlSGR4ZFVVelRWVjNRbFJJY1hWNGRVMEdPZ1pGVkE9PSIsImV4cCI6IjIwMjAtMDYtMjlUMTE6MjQ6NDMuMzU0WiIsInB1ciI6ImJsb2Jfa2V5In19--7c3ca50f3ba95ebe668fa9773b7ded6e71a71b9a/thematical-areas.png?content_type=image%2Fpng&disposition=inline%3B+filename%3D%22thematical-areas.png%22%3B+filename%2A%3DUTF-8%27%27thematical-areas.png 500 (Internal Server Error)
```

After the patch:
```
VM8:1 GET http://localhost:3000/rails/active_storage/disk/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaDFrVW5OSVZGbExlSGR4ZFVVelRWVjNRbFJJY1hWNGRVMEdPZ1pGVkE9PSIsImV4cCI6IjIwMjAtMDYtMjlUMTE6MjQ6NDMuMzU0WiIsInB1ciI6ImJsb2Jfa2V5In19--7c3ca50f3ba95ebe668fa9773b7ded6e71a71b9a/thematical-areas.png?content_type=image%2Fpng&disposition=inline%3B+filename%3D%22thematical-areas.png%22%3B+filename%2A%3DUTF-8%27%27thematical-areas.png 404 (Not Found)
```

![image](https://user-images.githubusercontent.com/1431026/85999060-7e02c380-ba03-11ea-81c3-b021bd4d6a62.png)

See https://github.com/rails/rails/issues/33647