### PR TITLE
add zoom styles and edit control styles to match px in designs

### DIFF
--- a/app/assets/images/icons/minus.svg
+++ b/app/assets/images/icons/minus.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="15" height="2" viewBox="0 0 15 2"><defs><style>.a{fill:#707070;}</style></defs><rect class="a" width="15" height="2" rx="1"/></svg>

--- a/app/assets/images/icons/plus.svg
+++ b/app/assets/images/icons/plus.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 15 15"><defs><style>.a{fill:#707070;}</style></defs><g transform="translate(0 0.314)"><rect class="a" width="15" height="2" rx="1" transform="translate(0 6.686)"/><rect class="a" width="15" height="2" rx="1" transform="translate(9 -0.314) rotate(90)"/></g></svg>

--- a/app/assets/stylesheets/components/_map.scss
+++ b/app/assets/stylesheets/components/_map.scss
@@ -4,63 +4,104 @@
 @import "maps/v-map-header";
 @import "maps/v-map-toggler";
 
+.map-section {
+  @include gutters;
+
+  @include breakpoint-down($small) {
+    padding: 0;
+  }
+}
+
 .map {
-  &--container {
-    @include gutters;
-
-    .map {
-      &__mapbox {
-        position: relative;
-
-        height: rem-calc(360);
-        @include breakpoint($medium) {
-          height: rem-calc(700);
-        }
-      }
+  &--main {
+    @include breakpoint($small) {
+      position: relative;
     }
 
     /**
-     * The following is part of a quick solution to the problem of having
-     * the header component within the filters component when it must 
-     * appear above the map and filters below on mobile devices. 
-     */
-    @include breakpoint($medium) {
+      * The following is part of a quick solution to the problem of having
+      * the header component within the filters component when it must 
+      * appear above the map and filters below on mobile devices. 
+      */
+    @include breakpoint($small) {
       & > .v-map-header {
         display: none;
       }
     }
 
-    // --------- BEGIN VMAPFILTERS GROUP --------- //
-    @include breakpoint($medium) {
+    .map__mapbox {
+      height: rem-calc(360);
+
       position: relative;
-    }
 
-    .v-map-filters {
-      @include breakpoint($medium) {
-        width: 33.33%;
-
-        position: absolute;
-        top: rem-calc(42);
-        left: $gutter-medium * 2;
-        z-index: 1;
-      }
-      @include breakpoint($large) {
-        left: $gutter-large * 2;
+      @include breakpoint($small) {
+        height: rem-calc(700);
       }
     }
-    // --------- ENDOF VMAPFILTERS GROUP --------- //
   }
 
+  &--search {
+    .map__map {
+      height: rem-calc(460);
+    }
+  }
+}
+
+.map {
   &__trigger {
     @include button-map-trigger;
     margin-right: rem-calc(16);
   }
+}
 
-  &--search {
-    .map {
-      &__map {
-        height: rem-calc(460);
-      }
+.mapboxgl-ctrl-top-right .mapboxgl-ctrl.mapboxgl-ctrl-group {
+  margin-top: rem-calc(13);
+  margin-right: rem-calc(10);
+  
+  @include breakpoint($small) {
+    margin-top: rem-calc(17);
+  }
+
+  @include breakpoint($medium) {
+    margin-top: rem-calc(32);
+    margin-right: rem-calc(16);
+  }
+}
+
+.mapboxgl-ctrl-bottom-left {
+  display: flex;
+  flex-direction: column-reverse;
+}
+
+.mapboxgl-ctrl.mapboxgl-ctrl-group:not(:empty) {
+  box-shadow: none;
+}
+
+.mapboxgl-ctrl-group {
+  .mapboxgl-ctrl-icon.mapboxgl-ctrl-zoom-in,
+  .mapboxgl-ctrl-icon.mapboxgl-ctrl-zoom-out {
+    border: solid rem-calc(1) $grey-dark;
+    background-color: $white;
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: rem-calc(12 12);
+    width: 30px; height: 33px;
+    
+    @include breakpoint($medium) {
+      background-size: rem-calc(20 20);
+      width: 42px; height: 45px;
     }
+
+    &:hover {
+      background-color: $grey-xlight;
+    }
+  }
+
+  .mapboxgl-ctrl-icon.mapboxgl-ctrl-zoom-in {
+    background-image: image-url('icons/plus.svg');
+  }
+
+  .mapboxgl-ctrl-icon.mapboxgl-ctrl-zoom-out {
+    background-image: image-url('icons/minus.svg');
   }
 }

--- a/app/assets/stylesheets/components/_map.scss
+++ b/app/assets/stylesheets/components/_map.scss
@@ -92,6 +92,11 @@
       width: 42px; height: 45px;
     }
 
+    &:focus:first-child,
+    &:focus:last-child {
+      border-radius: 0;
+    }
+
     &:hover {
       background-color: $grey-xlight;
     }

--- a/app/assets/stylesheets/components/maps/_v-map-baselayer-controls.scss
+++ b/app/assets/stylesheets/components/maps/_v-map-baselayer-controls.scss
@@ -3,35 +3,48 @@
 }
 .v-map-baselayer-controls {
   position: absolute;
-  right: rem-calc(46);
-  bottom: rem-calc(32);
+  bottom: rem-calc(10);
+  right: rem-calc(10);
 
-  display: flex;
-  align-content: flex-end;
+  @include breakpoint($small) {
+    bottom: rem-calc(16);
+  }
+
+  @include breakpoint($medium) {
+    right: rem-calc(16);
+  }
 
   &__control {
     min-width: rem-calc(100);
 
-    border: 1px solid darken($grey-xlight, 5%);
+    background-color: $white;
+    border: rem-calc(1px) solid $grey-dark;
     border-radius: 0;
     color: $black;
     cursor: pointer;
-    padding: rem-calc(12 25);
+    font-size: rem-calc(14);
+    width: rem-calc(82); height: rem-calc(35);
+
+    @include breakpoint($small) {
+      font-size: rem-calc(16);
+      width: rem-calc(140); height: rem-calc(46);
+    }
 
     &:not(:last-child) {
       border-right: none;
     }
+
     &.selected {
-      background-color: darken($grey-xlight, 5%);
+      background: $grey-dark;
+      color: $white;
     }
-    &:focus {
-      outline: none;
-    }
-    &:hover {
-      background-color: darken($grey-xlight, 10%);
-    }
-    &:active {
+
+    &:hover:not(.selected) {
       background-color: $grey-xlight;
+    }
+
+    &:active {
+      background-color: darken($grey-xlight, 10%);
     }
   }
 }

--- a/app/assets/stylesheets/components/maps/_v-map-baselayer-controls.scss
+++ b/app/assets/stylesheets/components/maps/_v-map-baselayer-controls.scss
@@ -18,7 +18,7 @@
     min-width: rem-calc(100);
 
     background-color: $white;
-    border: rem-calc(1px) solid $grey-dark;
+    border: rem-calc(1) solid $grey-dark;
     border-radius: 0;
     color: $black;
     cursor: pointer;

--- a/app/assets/stylesheets/components/maps/_v-map-filters.scss
+++ b/app/assets/stylesheets/components/maps/_v-map-filters.scss
@@ -40,10 +40,10 @@
 }
 
 .v-map-disclaimer {
-  justify-self: flex-end;
-
   font-size: rem-calc(14);
   margin-top: rem-calc(24);
+
+  justify-self: flex-end;
 
   &__heading {
     color: $white;

--- a/app/assets/stylesheets/components/maps/_v-map-filters.scss
+++ b/app/assets/stylesheets/components/maps/_v-map-filters.scss
@@ -2,14 +2,36 @@
   background-color: $grey-xdark;
   color: $grey-light;
 
+  @include breakpoint($small) {
+    width: rem-calc(340);
+
+    position: absolute;
+    top: rem-calc(17);
+    left: rem-calc(18);
+    z-index: 1;
+  }
+
+  @include breakpoint($medium) {
+    width: rem-calc(496);
+    
+    top: rem-calc(32);
+    left: rem-calc(43);
+  }
+
   .v-map-header {
-    @include breakpoint-down($medium) {
+    @include breakpoint-down($small) {
       display: none;
     }
   }
 
   &__body {
-    padding: rem-calc(14 24);
+    @include responsive(
+      padding,
+      rem-calc(30 18),
+      rem-calc(18 18 40),
+      rem-calc(18 18 40),
+      rem-calc(25 25 60),
+    );
 
     display: flex;
     flex-direction: column;
@@ -22,6 +44,7 @@
 
   font-size: rem-calc(14);
   margin-top: rem-calc(24);
+
   &__heading {
     color: $white;
     font-weight: $semi-bold;

--- a/app/javascript/components/map/default-options.js
+++ b/app/javascript/components/map/default-options.js
@@ -12,13 +12,15 @@ export const BASELAYERS_DEFAULT = [
 ]
 export const MAP_OPTIONS_DEFAULT = {
   container: 'map-target',
-  scrollZoom: false
+  scrollZoom: false,
+  attributionControl: false,
   //bounds: [[xmin,ymin],[xmax,ymax]],
 }
 export const CONTROLS_OPTIONS_DEFAULT = {
   showZoom: true,
   showCompass: false,
-  showBaselayerControls: true
+  showBaselayerControls: true,
+  attributionLocation: 'bottom-left'
 }
 export const EMPTY_OPTIONS = {
   map: null,

--- a/app/javascript/components/map/mixins/mixin-controls.js
+++ b/app/javascript/components/map/mixins/mixin-controls.js
@@ -1,14 +1,20 @@
+/* eslint-disable no-undef */
+
 export default {
   methods: {
     addControls () {
       if (this.controlsOptions.showZoom) {
         this.addZoomControls()
       }
+
+      this.map.addControl(
+        new mapboxgl.AttributionControl(), 
+        this.controlsOptions.attributionLocation
+      )
     },
 
     addZoomControls () {
       this.map.addControl(
-        //eslint-disable-next-line no-undef
         new mapboxgl.NavigationControl({
           showCompass: this.controlsOptions.showCompass
         })

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -14,7 +14,7 @@
   <%= render partial: "partials/cards/squares", locals: { cards: pas_categories } %>
 </section>
 
-<section>
+<section class="map-section">
   <%= render partial: "partials/maps/main" %>
 </section>
 

--- a/app/views/partials/maps/_main.html.erb
+++ b/app/views/partials/maps/_main.html.erb
@@ -1,4 +1,4 @@
-<div class="map--container">
+<div class="map--main">
   <v-map-header title="<%= @main_map[:title] %>"></v-map-header>
   <v-map></v-map>
   <v-map-filters


### PR DESCRIPTION
- Add zoom styling
- Use `$small` for tablet breakpoint
- Change some of the measurements to match xd designs
- Add dark grey (inverse) selected state to baselayer toggles (as advised by Charlotte) and adapt existing active/hover styles to suit
- Keep focus outline (for accessibility)
- Move attribution to bottom left (compact version on mobile needs fixing at a later date)
- Add padding to edge of map for tablet+