### PR TITLE
Checkbox bug fix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1018,7 +1018,7 @@ GEM
       rails (>= 5.2.0)
       rails-i18n (>= 5.0.0)
       sassc-rails (>= 2.0.0)
-    comfy_bootstrap_form (4.0.8)
+    comfy_bootstrap_form (4.0.7)
       rails (>= 5.0.0)
     concurrent-ruby (1.1.5)
     connection_pool (2.2.2)


### PR DESCRIPTION
**Ticket**

https://unep-wcmc.codebasehq.com/projects/pp-refresh/tickets/100

I rolled back `comfy_bootstrap_form` version to 4.0.7 to allow checkboxes in the CMS to be selected once more. It seems to be related to incorrect inputs present in the form inside the Comfy gem. 