### PR TITLE
custom filter checkboxes cms tag created

### DIFF
--- a/app/assets/javascripts/comfy/admin/cms/custom.js
+++ b/app/assets/javascripts/comfy/admin/cms/custom.js
@@ -1,2 +1,3 @@
 //= require 'comfy/admin/cms/versions'
 //= require 'comfy/admin/cms/editor'
+//= require 'comfy/admin/cms/filters'

--- a/app/assets/javascripts/comfy/admin/cms/filters.js.coffee
+++ b/app/assets/javascripts/comfy/admin/cms/filters.js.coffee
@@ -1,12 +1,18 @@
 $(document).ready( ->
+  # Made it able to support any number of options
+  customCheckboxes = document.getElementsByClassName('filter-checkbox');
+  customElems = Array.from(customCheckboxes).map((elem) => elem.innerText);
+
+
   # Create a change event listener for each topic checkbox.
   # This will add or remove the related substring in the content input tag.
-  ['WDPA', 'OECM', 'PAME'].forEach((el) =>
-    $('#fragment-topic_'+el).change((event) =>
+
+  customElems.forEach((el) =>
+    $('#fragment-topic_' + el).change((event) =>
       $content = $('#fragment-topic_content')
       _val = $content.val()
       if (event.target.checked)
-        $content.val(_val+' '+el)
+        $content.val(_val + ' ' + el)
       else
         $content.val(_val.replace(el, '').trim())
     )

--- a/app/assets/javascripts/comfy/admin/cms/filters.js.coffee
+++ b/app/assets/javascripts/comfy/admin/cms/filters.js.coffee
@@ -4,11 +4,11 @@ $(document).ready( ->
   ['WDPA', 'OECM', 'PAME'].forEach((el) =>
     $('#fragment-topic_'+el).change((event) =>
       $content = $('#fragment-topic_content')
-      _val = $content.val()  
+      _val = $content.val()
       if (event.target.checked)
         $content.val(_val+' '+el)
       else
-        $content.val(_val.replace(' '+el, ''))
+        $content.val(_val.replace(el, '').trim())
     )
   )
 )

--- a/app/assets/javascripts/comfy/admin/cms/filters.js.coffee
+++ b/app/assets/javascripts/comfy/admin/cms/filters.js.coffee
@@ -1,0 +1,14 @@
+$(document).ready( ->
+  # Create a change event listener for each topic checkbox.
+  # This will add or remove the related substring in the content input tag.
+  ['WDPA', 'OECM', 'PAME'].forEach((el) =>
+    $('#fragment-topic_'+el).change((event) =>
+      $content = $('#fragment-topic_content')
+      _val = $content.val()  
+      if (event.target.checked)
+        $content.val(_val+' '+el)
+      else
+        $content.val(_val.replace(' '+el, ''))
+    )
+  )
+)

--- a/app/assets/javascripts/comfy/admin/cms/filters.js.coffee
+++ b/app/assets/javascripts/comfy/admin/cms/filters.js.coffee
@@ -3,13 +3,15 @@ $(document).ready( ->
   customCheckboxes = document.getElementsByClassName('filter-checkbox');
   customElems = Array.from(customCheckboxes).map((elem) => elem.innerText);
 
-
+  # Get name of fragment
+  fragmentName = document.querySelectorAll('input[value=filter_checkboxes]')[0].parentElement.previousSibling.innerText.toLowerCase()
+  
   # Create a change event listener for each topic checkbox.
   # This will add or remove the related substring in the content input tag.
 
   customElems.forEach((el) =>
-    $('#fragment-topic_' + el).change((event) =>
-      $content = $('#fragment-topic_content')
+    $('#fragment-' + fragmentName + '_' + el).change((event) =>
+      $content = $('#fragment-' + fragmentName + '_content')
       _val = $content.val()
       if (event.target.checked)
         $content.val(_val + ' ' + el)

--- a/config/initializers/comfortable_mexican_sofa.rb
+++ b/config/initializers/comfortable_mexican_sofa.rb
@@ -2,6 +2,7 @@
 
 require 'cms_tags/date_not_null'
 require 'cms_tags/text_custom'
+require 'cms_tags/filter_checkboxes'
 # encoding: utf-8
 
 ComfortableMexicanSofa.configure do |config|

--- a/lib/cms_tags/filter_checkboxes.rb
+++ b/lib/cms_tags/filter_checkboxes.rb
@@ -4,6 +4,15 @@ class FilterCheckboxes < ComfortableMexicanSofa::Content::Tag::Fragment
     @custom_categories = options['options'].split(',').map do |category|
       category = category.strip
     end
+
+    @custom_categories.each do |category|
+      class_eval { attr_accessor category }
+      instance_variable_set "@#{category}", false
+    end
+  end
+
+  def content(category)
+    self.send(category)
   end
   
   def form_field(object_name, view, index)
@@ -19,14 +28,21 @@ class FilterCheckboxes < ComfortableMexicanSofa::Content::Tag::Fragment
                       class: "form-check-input"               
                   } 
 
-                  view.concat view.hidden_field_tag(name, "0", id: nil)
-                  view.concat view.check_box_tag(name, "1", false, options)
+                  view.concat view.hidden_field_tag(name, "#{category}: #{content(category)}", id: nil)
+                  view.concat view.check_box_tag(name, "1", parse_content(category), options)
                   view.concat view.label_tag(category, nil, class: 'form-check-label pr-3')
                 end
               end
             
 
     yield input
+  end
+
+  private
+
+  def parse_content
+    # TODO: Need to write a function to parse the content attribute of the fragment that is submitted via the form.
+    false
   end
 
 end

--- a/lib/cms_tags/filter_checkboxes.rb
+++ b/lib/cms_tags/filter_checkboxes.rb
@@ -1,57 +1,39 @@
 class FilterCheckboxes < ComfortableMexicanSofa::Content::Tag::Fragment
   def initialize(context:, params: [], source: nil)
     super
-    @custom_categories = options['options'].split(',').map do |category|
-      category = category.strip
-    end
-
-    @custom_categories.each do |category|
-      class_eval { attr_accessor category }
-      instance_variable_set "@#{category}", false
-    end
-  end
-
-  def store_in_content(category)
-    value = self.send(category)
-    fragment.content << " #{category} #{value} "
+    @custom_categories = options['options'].split(',').map(&:strip)
   end
   
   def form_field(object_name, view, index)
     name = "#{object_name}[fragments_attributes][#{index}][content]"
 
-    # Clearing the fragment's content before populating it with booleans stored
-    # as strings
-    fragment.content = ""
-
     input =   view.content_tag(:div, class: "form-check form-check-inline") do
+                # There should only be one content tag, so this goes outside the categories loop
+                view.concat view.hidden_field_tag(name, content, id: "#{form_field_id}_content")
+
                 @custom_categories.each do |category|
           
-                  options = { 
-                      id: form_field_id, 
-                      class: "form-check-input"               
-                  } 
+                  # id will be used by the custom javascript to change the content when
+                  # ticking or unticking the related checkbox
+                  options = {
+                    id: "#{form_field_id}_#{category}",
+                    class: "form-check-input"
+                  }
 
-                  view.concat view.hidden_field_tag(name, category, id: nil)
-                  store_in_content(category)
-                  view.concat view.check_box_tag(name, "1", parse_content(category), options) 
-                  view.concat view.label_tag(category, nil, class: 'form-check-label pr-3')
+                  # filter-checkbox name is just a dummy name which is not actually used
+                  view.concat view.check_box_tag("filter-checkbox", category, parse_content(category), options) 
+                  view.concat view.label_tag(name, category, class: 'form-check-label pr-3')
                 end
               end
             
-  
     yield input
   end
 
   private
 
   def parse_content(category)
-    return false if fragment.content == ""
-
-    stored_values = fragment.content.split(' ')
-    
-    # Making sure to grab the boolean (in string format) that follows every
-    # option name in the transmogrified fragment
-    ActiveModel::Type::Boolean.new.cast(stored_values[stored_values.find_index(category) + 1])
+    return false if fragment.content.blank?
+    fragment.content.split(' ').include?(category)
   end
 
 end

--- a/lib/cms_tags/filter_checkboxes.rb
+++ b/lib/cms_tags/filter_checkboxes.rb
@@ -4,20 +4,10 @@ class FilterCheckboxes < ComfortableMexicanSofa::Content::Tag::Fragment
     @custom_categories = options['options'].split(',').map do |category|
       category = category.strip
     end
-
-    @custom_categories.each do |category|
-      class_eval { attr_accessor category }
-      instance_variable_set :"@#{category}", false
-    end
-  end
-
-  def content(category)
-    self.send(category)
   end
   
-
   def form_field(object_name, view, index)
-    name = "#{object_name}[fragments_attributes][#{index}][boolean]"
+    name = "#{object_name}[fragments_attributes][#{index}][content]"
 
     
     
@@ -26,11 +16,11 @@ class FilterCheckboxes < ComfortableMexicanSofa::Content::Tag::Fragment
           
                   options = { 
                       id: form_field_id, 
-                      class: "form-check-input"                
+                      class: "form-check-input"               
                   } 
 
                   view.concat view.hidden_field_tag(name, "0", id: nil)
-                  view.concat view.check_box_tag(name, "1", content(category), options)
+                  view.concat view.check_box_tag(name, "1", false, options)
                   view.concat view.label_tag(category, nil, class: 'form-check-label pr-3')
                 end
               end

--- a/lib/cms_tags/filter_checkboxes.rb
+++ b/lib/cms_tags/filter_checkboxes.rb
@@ -22,7 +22,7 @@ class FilterCheckboxes < ComfortableMexicanSofa::Content::Tag::Fragment
 
                   # filter-checkbox name is just a dummy name which is not actually used
                   view.concat view.check_box_tag("filter-checkbox", category, parse_content(category), options) 
-                  view.concat view.label_tag(name, category, class: 'form-check-label pr-3')
+                  view.concat view.label_tag(name, category, class: 'form-check-label filter-checkbox pr-3')
                 end
               end
             

--- a/lib/cms_tags/filter_checkboxes.rb
+++ b/lib/cms_tags/filter_checkboxes.rb
@@ -1,0 +1,47 @@
+class FilterCheckboxes < ComfortableMexicanSofa::Content::Tag::Fragment
+  def initialize(context:, params: [], source: nil)
+    super
+    @custom_categories = options['options'].split(',').map do |category|
+      category = category.strip
+    end
+
+    @custom_categories.each do |category|
+      class_eval { attr_accessor category }
+      instance_variable_set :"@#{category}", false
+    end
+  end
+
+  def content(category)
+    self.send(category)
+  end
+  
+
+  def form_field(object_name, view, index)
+    name = "#{object_name}[fragments_attributes][#{index}][boolean]"
+
+    
+    
+    input =   view.content_tag(:div, class: "form-check form-check-inline") do
+                @custom_categories.each do |category|
+          
+                  options = { 
+                      id: form_field_id, 
+                      class: "form-check-input"                
+                  } 
+
+                  view.concat view.hidden_field_tag(name, "0", id: nil)
+                  view.concat view.check_box_tag(name, "1", content(category), options)
+                  view.concat view.label_tag(category, nil, class: 'form-check-label pr-3')
+                end
+              end
+            
+
+    yield input
+  end
+
+end
+
+ComfortableMexicanSofa::Content::Renderer.register_tag(
+    :filter_checkboxes, FilterCheckboxes
+)
+  

--- a/lib/cms_tags/filter_checkboxes.rb
+++ b/lib/cms_tags/filter_checkboxes.rb
@@ -11,15 +11,18 @@ class FilterCheckboxes < ComfortableMexicanSofa::Content::Tag::Fragment
     end
   end
 
-  def value_of_content(category)
-    self.send(category)
+  def store_in_content(category)
+    value = self.send(category)
+    fragment.content << " #{category} #{value} "
   end
   
   def form_field(object_name, view, index)
     name = "#{object_name}[fragments_attributes][#{index}][content]"
 
-    
-    
+    # Clearing the fragment's content before populating it with booleans stored
+    # as strings
+    fragment.content = ""
+
     input =   view.content_tag(:div, class: "form-check form-check-inline") do
                 @custom_categories.each do |category|
           
@@ -28,22 +31,27 @@ class FilterCheckboxes < ComfortableMexicanSofa::Content::Tag::Fragment
                       class: "form-check-input"               
                   } 
 
-                  view.concat view.hidden_field_tag(name, "#{category}", id: nil)
-                  view.concat view.check_box_tag(name, "1", parse_content(category), options)
+                  view.concat view.hidden_field_tag(name, category, id: nil)
+                  store_in_content(category)
+                  view.concat view.check_box_tag(name, "1", parse_content(category), options) 
                   view.concat view.label_tag(category, nil, class: 'form-check-label pr-3')
                 end
               end
             
-
+  
     yield input
   end
 
   private
 
-  def parse_content
-    return if self.content == ""
-    # TODO: Need to write a function to parse the content attribute of the fragment that is submitted via the form.
-    false
+  def parse_content(category)
+    return false if fragment.content == ""
+
+    stored_values = fragment.content.split(' ')
+    
+    # Making sure to grab the boolean (in string format) that follows every
+    # option name in the transmogrified fragment
+    ActiveModel::Type::Boolean.new.cast(stored_values[stored_values.find_index(category) + 1])
   end
 
 end

--- a/lib/cms_tags/filter_checkboxes.rb
+++ b/lib/cms_tags/filter_checkboxes.rb
@@ -11,7 +11,7 @@ class FilterCheckboxes < ComfortableMexicanSofa::Content::Tag::Fragment
     end
   end
 
-  def content(category)
+  def value_of_content(category)
     self.send(category)
   end
   
@@ -28,7 +28,7 @@ class FilterCheckboxes < ComfortableMexicanSofa::Content::Tag::Fragment
                       class: "form-check-input"               
                   } 
 
-                  view.concat view.hidden_field_tag(name, "#{category}: #{content(category)}", id: nil)
+                  view.concat view.hidden_field_tag(name, "#{category}", id: nil)
                   view.concat view.check_box_tag(name, "1", parse_content(category), options)
                   view.concat view.label_tag(category, nil, class: 'form-check-label pr-3')
                 end
@@ -41,6 +41,7 @@ class FilterCheckboxes < ComfortableMexicanSofa::Content::Tag::Fragment
   private
 
   def parse_content
+    return if self.content == ""
     # TODO: Need to write a function to parse the content attribute of the fragment that is submitted via the form.
     false
   end


### PR DESCRIPTION
**Ticket**

https://unep-wcmc.codebasehq.com/projects/pp-refresh/tickets/130

Created a custom checkbox component that is designed to be used to populate filters in the News and Stories section. This can be added to the CMS and passed any number of string arguments, as well as whatever name the user wants to add - these arguments are initialised as part of the FilterCheckbox fragment attributes so could probably be accessed using `cms_fragment_content` by the front end or something similiar. Might need a bit of styling, but just want to check that it works as it should first. 

P.S. New branch has been created in the db submodule as I've edited `db/cms_seeds/protected-planet/layouts/template-basic/content.html` to include two of these tags. 