### PR TITLE
Location search

### DIFF
--- a/app/controllers/country_controller.rb
+++ b/app/controllers/country_controller.rb
@@ -39,7 +39,7 @@ class CountryController < ApplicationController
     }
 
     @map_options = {
-      map: { boundsUrl: country_extent_url(@country.iso_3) }
+      map: { boundsUrl: @country.extent_url }
     }
     
     ##TODO need adding

--- a/app/controllers/region_controller.rb
+++ b/app/controllers/region_controller.rb
@@ -32,7 +32,7 @@ class RegionController < ApplicationController
     }
 
     @map_options = {
-      map: { boundsUrl: region_extent_url(@region.name) }
+      map: { boundsUrl: @region.extent_url }
     }
   end
 

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -38,22 +38,23 @@ class SearchController < ApplicationController
 
   def autocomplete
     db_type = search_params[:type]
-
-    case db_type
-      when 'country'
-        index = Search::COUNTRY_INDEX
-      when 'region'
-        index = Search::REGION_INDEX
-      else
-        index = Search::PA_INDEX
-    end
-
-    @results = Autocompletion.lookup(search_params[:search_term], db_type, index)
+    @results = Autocompletion.lookup(search_params[:search_term], db_type, search_index(db_type))
 
     render json: @results
   end
 
   private
+
+  def search_index db_type
+    case db_type
+      when 'country'
+        Search::COUNTRY_INDEX
+      when 'region'
+        Search::REGION_INDEX
+      else
+        Search::PA_INDEX
+    end
+  end
 
   def search_params
     params.permit(:search_term, :type, :requested_page, :items_per_page, :filters)

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -37,7 +37,18 @@ class SearchController < ApplicationController
   end
 
   def autocomplete
-    @results = Autocompletion.lookup(search_params[:search_term], search_params[:type])
+    db_type = search_params[:type]
+
+    case db_type
+      when 'country'
+        index = Search::COUNTRY_INDEX
+      when 'region'
+        index = Search::REGION_INDEX
+      else
+        index = Search::PA_INDEX
+    end
+
+    @results = Autocompletion.lookup(search_params[:search_term], db_type, index)
 
     render json: @results
   end

--- a/app/helpers/map_helper.rb
+++ b/app/helpers/map_helper.rb
@@ -63,4 +63,14 @@ module MapHelper
       padding: 5
     }
   end
+
+  def map_search_types
+    arr = []
+
+    t('map.search_types').each do |id, translations|
+      arr.push(translations.merge({id: id}))
+    end
+
+    arr
+  end
 end

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -1,5 +1,6 @@
 class Country < ApplicationRecord
   include GeometryConcern
+  include MapHelper
 
   has_and_belongs_to_many :protected_areas
 
@@ -48,6 +49,10 @@ class Country < ApplicationRecord
     # TODO This line is now breaking the indexing. It looks like it's not require anymore
     #js['region_name'] = js['region_for_index']['name']
     js
+  end
+
+  def extent_url
+    country_extent_url(iso_3)
   end
 
   def random_protected_areas wanted=1

--- a/app/models/region.rb
+++ b/app/models/region.rb
@@ -1,5 +1,6 @@
 class Region < ApplicationRecord
   include GeometryConcern
+  include MapHelper
 
   has_many :countries
   has_many :protected_areas, through: :countries
@@ -106,6 +107,10 @@ class Region < ApplicationRecord
     self.as_json(
       only: [:id, :name, :iso]
     )
+  end
+
+  def extent_url
+    region_extent_url(name)
   end
 
   def protected_areas_per_designation(jurisdiction=nil)

--- a/app/views/partials/maps/_main.html.erb
+++ b/app/views/partials/maps/_main.html.erb
@@ -11,7 +11,7 @@
         v-if="<%= !map[:areFiltersHidden] %>"
         :autocomplete-error-messages="<%= map_yml[:autocomplete_error_messages].to_json %>"
         :dropdown-label="<%= map_yml[:dropdown_label].to_json %>"
-        :search-types="<%= map_yml[:search_types].to_json %>"
+        :search-types="<%= map_search_types.to_json %>"
       />
     </template>
     <template v-slot:bottom>

--- a/config/locales/main_map/en.yml
+++ b/config/locales/main_map/en.yml
@@ -13,16 +13,13 @@ en:
       body: The designations employed and the presentation of material on this map do not imply the expression of any opinion whatsoever on the part of the Secretariat of the United Nations concerning the legal status of any country, territory, city or area or of its authorities, or concerning the delimitation of its frontiers or boundaries.
     dropdown_label: Search for a
     search_types:
-      -
-        id: country
+      country:
         title: Country
         placeholder: Search...
-      -
-        id: region
+      region:
         title: Region
         placeholder: Search...
-      -
-        id: site
+      site:
         title: Protected Area or OECM
         placeholder: Search...
     autocomplete_error_messages:

--- a/config/locales/main_map/en.yml
+++ b/config/locales/main_map/en.yml
@@ -22,8 +22,8 @@ en:
         title: Region
         placeholder: Search...
       -
-        id: wdpa
-        title: Protected Area
+        id: site
+        title: Protected Area or OECM
         placeholder: Search...
     autocomplete_error_messages:
       no_results: The search term has no results.

--- a/lib/modules/autocompletion.rb
+++ b/lib/modules/autocompletion.rb
@@ -33,12 +33,13 @@ module Autocompletion
   private
 
   def self.get_filters(type)
-    if type == 'wdpa'
-      { filters: { is_oecm: false } }
-    elsif type == 'oecm'
-      { filters: { is_oecm: true } }
-    else
-      {}
+    case type
+      when 'wdpa'
+        { filters: { is_oecm: false } }
+      when 'oecm'
+        { filters: { is_oecm: true } }
+      else
+        {}
     end
   end
 

--- a/lib/modules/autocompletion.rb
+++ b/lib/modules/autocompletion.rb
@@ -2,12 +2,12 @@ module Autocompletion
   AUTOCOMPLETION_KEY = "autocompletion".freeze
   IDENTIFIER_FIELDS = {
     'protected_area' => :wdpa_id,
-    'country' => :iso_3
+    'country' => :iso_3,
+    'region' => :iso
   }.freeze
 
   def self.lookup(term, db_type='wdpa', search_index=Search::PA_INDEX)
-    filters = { filters: { is_oecm: db_type == 'oecm' } }
-    search = Search.search(term.downcase, filters, search_index)
+    search = Search.search(term.downcase, get_filters(db_type), search_index)
 
     results = search.results.objects.values.compact.flatten
 
@@ -31,6 +31,16 @@ module Autocompletion
   end
 
   private
+
+  def self.get_filters(type)
+    if type == 'wdpa'
+      { filters: { is_oecm: false } }
+    elsif type == 'oecm'
+      { filters: { is_oecm: true } }
+    else
+      {}
+    end
+  end
 
   def self.get_type(type, identifier)
     if type == 'country' || type == 'region'

--- a/lib/modules/autocompletion.rb
+++ b/lib/modules/autocompletion.rb
@@ -17,7 +17,7 @@ module Autocompletion
       identifier = result.send(identifier_field(type))
 
       geom_type = result.is_a?(ProtectedArea) ? result.the_geom.geometry_type.to_s : 'N/A'
-      url = type == 'country' ? "/country/#{identifier}" : "/#{identifier}"
+      url = get_type(type, identifier)
       extent_url = result.respond_to?(:extent_url) ? result.extent_url : 'N/A'
 
       {
@@ -31,6 +31,14 @@ module Autocompletion
   end
 
   private
+
+  def self.get_type(type, identifier)
+    if type == 'country' || type == 'region'
+      "/#{type}/#{identifier}"
+    else
+      "/#{identifier}"
+    end
+  end
 
   def self.identifier_field(type)
     IDENTIFIER_FIELDS[type] || :id


### PR DESCRIPTION
This adds extent_url method to country and region models.

Also only adds oecm filter to search if 'oecm' or 'wdpa' is the db_type. Otherwise filters = {}

You can test this on the map search on the homepage.

BUG: I can't get OECMs to be found either if I set db_type = oecm or db_type = site (therefore filters = {})... 