### PR TITLE
Add source csv to zip on shp downloads

### DIFF
--- a/lib/modules/download/generators/shapefile.rb
+++ b/lib/modules/download/generators/shapefile.rb
@@ -104,6 +104,11 @@ class Download::Generators::Shapefile < Download::Generators::Base
     range = (0..@number_of_pieces-1)
     files_paths = range.map { |i| zip_path(i) }.join(' ')
     system("zip -j #{zip_path} #{files_paths}") and system("zip -ru #{zip_path} *", chdir: ATTACHMENTS_PATH)
+    system("zip -ru #{zip_path} #{File.basename(sources_path)}", chdir: File.dirname(sources_path))
     range.each { |i| FileUtils.rm_rf(zip_path(i)) }
+  end
+
+  def sources_path
+    File.join(File.dirname(zip_path), "WDPA_sources.csv")
   end
 end


### PR DESCRIPTION
This is to add the source table as csv to the zip file whne users download shp. Previously the source table was included only when downloading csv format

[Codebase ticket](https://unep-wcmc.codebasehq.com/projects/protected-planet-support-and-maintenance/tickets/70)