### PR TITLE
Ticket 150

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,7 @@
 source 'https://rubygems.org'
-source 'https://wcmc-gems:SDvUM6ZG@gem-server.unep-wcmc.org/'
 
 gem 'rails', '5.2.0'
 gem 'webpacker', '~> 4.0.2'
-
-#gem 'wcmc-components', path: "../web-components/gems/wcmc_components"
-gem 'wcmc-components', '~>0.0.5'
-
 
 gem 'bourbon'
 gem "neat"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,6 @@ GIT
 
 GEM
   remote: https://rubygems.org/
-  remote: https://wcmc-gems:SDvUM6ZG@gem-server.unep-wcmc.org/
   specs:
     actioncable (5.2.0)
       actionpack (= 5.2.0)
@@ -1282,7 +1281,6 @@ GEM
     vuejs-rails (2.3.2)
     warden (1.2.8)
       rack (>= 2.0.6)
-    wcmc-components (0.0.5)
     webmock (1.22.6)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -1365,7 +1363,6 @@ DEPENDENCIES
   turnout (~> 2.5.0)
   uglifier (~> 4.1.17)
   vuejs-rails (~> 2.3.2)
-  wcmc-components (~> 0.0.5)
   webmock (~> 1.22.0)
   webpacker (~> 4.0.2)
   whenever

--- a/app/models/pame_evaluation.rb
+++ b/app/models/pame_evaluation.rb
@@ -1,5 +1,4 @@
 require 'csv'
-require 'wcmc_components'
 
 class PameEvaluation < ApplicationRecord
   belongs_to :protected_area, optional: true

--- a/app/models/pame_evaluation.rb
+++ b/app/models/pame_evaluation.rb
@@ -2,20 +2,11 @@ require 'csv'
 require 'wcmc_components'
 
 class PameEvaluation < ApplicationRecord
-  include WcmcComponents::Loadable
-
   belongs_to :protected_area, optional: true
   belongs_to :pame_source
   has_and_belongs_to_many :countries
 
   validates :methodology, :year, :metadata_id, presence: true
-
-  # config for loadable mixin
-  ignore_column :designation
-
-  import_by protected_area: :wdpa_id
-  import_by countries: :iso_3
-  
 
   TABLE_ATTRIBUTES = [
     {

--- a/app/models/pame_evaluation.rb
+++ b/app/models/pame_evaluation.rb
@@ -245,7 +245,7 @@ class PameEvaluation < ApplicationRecord
                GROUP BY pame_evaluations.id, protected_areas.wdpa_id, protected_areas.name, designation, pame_sources.data_title,
                         pame_sources.resp_party, pame_sources.year, pame_sources.language
 
-               UNION
+       /*        UNION
 
         SELECT pame_evaluations.id AS id,
                pame_evaluations.metadata_id AS metadata_id,
@@ -267,6 +267,7 @@ class PameEvaluation < ApplicationRecord
                #{restricted_where_statement}
                GROUP BY pame_evaluations.id, wdpa_id, pame_evaluations.name, designation, pame_sources.data_title,
                         pame_sources.resp_party, pame_sources.year, pame_sources.language;
+      */
       SQL
     evaluations = ActiveRecord::Base.connection.execute(query)
 

--- a/lib/modules/wdpa/pame_importer.rb
+++ b/lib/modules/wdpa/pame_importer.rb
@@ -1,11 +1,88 @@
 require 'csv'
 
 module Wdpa::PameImporter
-  PAME_EVALUATIONS = "#{Rails.root}/lib/data/seeds/pame_data-2019-08-30.csv".freeze
 
-  def self.import (csv_file=nil)
-    csv_file ||= PAME_EVALUATIONS
-    PameEvaluation.import csv_file, "UTF-8"
+  PAME_EVALUATIONS = "#{Rails.root}/lib/data/seeds/pame_data-2019-08-30.csv".freeze
+  # TODO Restore the following when on production (maybe also staging)
+  #PAME_EVALUATIONS = "#{Rails.root}/lib/data/seeds/pame_data-2020-05-28.csv".freeze
+
+  def self.import(csv_file=nil)
+    puts "Deleting old PAME evaluations..."
+    PameEvaluation.delete_all
+    puts "Importing PAME evaluations..."
+    hidden_evaluations = []
+
+    csv_file = csv_file || PAME_EVALUATIONS
+
+    CSV.foreach(csv_file, headers: true) do |row|
+      id                   = row[0].to_i
+      wdpa_id              = row[1].to_i
+      methodology          = row[3]
+      year                 = row[4].to_i
+      protected_area       = ProtectedArea.find_by_wdpa_id(wdpa_id) || nil
+      metadata_id          = row[6].to_i
+      name                 = row[7]
+      url                  = row[5]
+      restricted           = row[13] == "FALSE" ? false : true
+      assessment_is_public = row[14] == "FALSE" ? false : true
+
+      if assessment_is_public
+        url = url.blank? ? "Not currently public" : url
+      else
+        url = "Not reported"
+      end
+
+      iso3s           = row[2]
+      pame_source     = PameSource.where({
+        data_title: row[9],
+        resp_party: row[10],
+        year:       row[11].to_i,
+        language:   row[12]
+        }).first_or_create do |ps|
+          # if the record doesn't exist, create it...
+          ps.data_title = row[9]
+          ps.resp_party = row[10]
+          ps.year       = row[11].to_i
+          ps.language   = row[12]
+        end
+
+      pame_evaluation = PameEvaluation.where({
+        id: id,
+        protected_area: protected_area,
+        methodology: methodology,
+        year: year,
+        metadata_id: metadata_id,
+        url: url,
+        pame_source: pame_source,
+        restricted: restricted
+      }).first_or_create do |pe|
+        # If the record doesn't exist, create it...
+        pe.id                   = id
+        pe.protected_area       = protected_area
+        pe.methodology          = methodology
+        pe.year                 = year
+        pe.metadata_id          = metadata_id
+        pe.url                  = url
+        pe.pame_source          = pame_source
+        pe.restricted           = restricted
+        pe.wdpa_id              = wdpa_id
+        pe.name                 = name
+        pe.assessment_is_public = assessment_is_public
+      end
+      if protected_area.nil?
+        hidden_evaluations << wdpa_id unless restricted
+      end
+
+      iso3s.split(",").each do |iso3|
+        country = Country.find_by(iso_3: iso3)
+        if country.present?
+          pame_evaluation.countries << country unless pame_evaluation.countries.include? country
+        end
+      end
+    end
+
+    puts "Import finished!"
+    puts "The following are hidden: #{hidden_evaluations.count}"
+    puts hidden_evaluations.join(",")
   end
-  
 end


### PR DESCRIPTION
## Description

* Restore original Pame importer as it wasn't importing the `wdpa_id` field correctly, resulting in some issues also with the download (e.g. showing 0 for that field and having the same evaluation downloaded multiple times because wouldn't be able to match fields using the UNION statement; which statement has also be removed by the way)

* Remove UNION statement for downloading hidden evaluations (where protected_area_id is empty) so that the CSV matches exactly what it shown on the table.

## Notes

[Codebase ticket](https://unep-wcmc.codebasehq.com/projects/pp-refresh/tickets/150)