### PR TITLE
added dependent destroy on pages categories to allow deletion

### DIFF
--- a/config/initializers/comfy_patching.rb
+++ b/config/initializers/comfy_patching.rb
@@ -1,6 +1,6 @@
 Rails.configuration.to_prepare do
   Comfy::Cms::Page.class_eval do
-    has_many :pages_categories, foreign_key: 'page_id'
+    has_many :pages_categories, foreign_key: 'page_id', dependent: :destroy
     has_many :page_categories, through: :pages_categories, foreign_key: 'page_id'
 
     has_many :topics, -> { joins(:layout_category).where("comfy_cms_layout_categories.label = 'topics'") },


### PR DESCRIPTION
To test, try deleting pages with the custom tags added and it should successfully delete. 