### PR TITLE
Allow custom datetime tag to work

### DIFF
--- a/app/helpers/cms_helper.rb
+++ b/app/helpers/cms_helper.rb
@@ -194,9 +194,7 @@ module CmsHelper
   end
 
   def cms_fragment_content_datetime(identifier, page)
-    return cms_fragment_content(identifier, page) unless identifier == 'published_date'
-    date_fragments = page.fragments.where(identifier: 'published_date')
-    date_not_null = date_fragments.find_by(tag: 'date_not_null')
-    date_not_null ? date_not_null.datetime : date_fragments.first.datetime
+    date_not_null = page.fragments.find_by(tag: 'date_not_null', identifier: identifier)
+    date_not_null.datetime 
   end
 end

--- a/app/helpers/cms_helper.rb
+++ b/app/helpers/cms_helper.rb
@@ -194,6 +194,7 @@ module CmsHelper
   end
 
   def cms_fragment_content_datetime(identifier, page)
-    page.fragments.find_by(tag: 'date_not_null', identifier: identifier).datetime
+    # Might not be able to find that particular tag and identifier combo -  hence the try
+    page.fragments.find_by(tag: 'date_not_null', identifier: identifier).try(:datetime)
   end
 end

--- a/app/helpers/cms_helper.rb
+++ b/app/helpers/cms_helper.rb
@@ -193,8 +193,10 @@ module CmsHelper
     end
   end
 
-  def cms_fragment_content_datetime(identifier, page = @cms_page)
-    return cms_fragment_content(identifier, page) unless page.fragments.pluck(:tag).include?('date_not_null')
-    page.fragments.find_by(tag: 'date_not_null').datetime
+  def cms_fragment_content_datetime(identifier, page)
+    return cms_fragment_content(identifier, page) unless identifier == 'published_date'
+    date_fragments = page.fragments.where(identifier: 'published_date')
+    date_not_null = date_fragments.find_by(tag: 'date_not_null')
+    date_not_null ? date_not_null.datetime : date_fragments.first.datetime
   end
 end

--- a/app/helpers/cms_helper.rb
+++ b/app/helpers/cms_helper.rb
@@ -192,4 +192,9 @@ module CmsHelper
       false
     end
   end
+
+  def cms_fragment_content_datetime(identifier, page = @cms_page)
+    return cms_fragment_content(identifier, page) unless page.fragments.pluck(:tag).include?('date_not_null')
+    page.fragments.find_by(tag: 'date_not_null').datetime
+  end
 end

--- a/app/helpers/cms_helper.rb
+++ b/app/helpers/cms_helper.rb
@@ -195,7 +195,7 @@ module CmsHelper
 
   def cms_fragment_content_datetime(identifier, page)
     # Might not be able to find that particular tag and identifier combo -  hence the try
-    page.fragments.find_by(tag: 'date_not_null', identifier: identifier).try(:datetime)
+    date = page.fragments.find_by(tag: 'date_not_null', identifier: identifier).try(:datetime)
     date ? date : cms_fragment_content(identifier, page)
   end
 end

--- a/app/helpers/cms_helper.rb
+++ b/app/helpers/cms_helper.rb
@@ -196,5 +196,6 @@ module CmsHelper
   def cms_fragment_content_datetime(identifier, page)
     # Might not be able to find that particular tag and identifier combo -  hence the try
     page.fragments.find_by(tag: 'date_not_null', identifier: identifier).try(:datetime)
+    date ? date : cms_fragment_content(identifier, page)
   end
 end

--- a/app/helpers/cms_helper.rb
+++ b/app/helpers/cms_helper.rb
@@ -194,7 +194,6 @@ module CmsHelper
   end
 
   def cms_fragment_content_datetime(identifier, page)
-    date_not_null = page.fragments.find_by(tag: 'date_not_null', identifier: identifier)
-    date_not_null.datetime 
+    page.fragments.find_by(tag: 'date_not_null', identifier: identifier).datetime
   end
 end

--- a/app/serializers/search/cms_serializer.rb
+++ b/app/serializers/search/cms_serializer.rb
@@ -57,7 +57,7 @@ class Search::CmsSerializer < Search::BaseSerializer
   end
 
   def date(page)
-    _date = cms_fragment_content(:published_date, page)
+    _date = cms_fragment_content_datetime(:published_date, page)
     _date.present? ? _date.strftime('%d %B %y') : _date
   end
 

--- a/app/serializers/search/cms_serializer.rb
+++ b/app/serializers/search/cms_serializer.rb
@@ -58,7 +58,7 @@ class Search::CmsSerializer < Search::BaseSerializer
 
   def date(page)
     _date = cms_fragment_content_datetime(:published_date, page)
-    _date.present? ? _date.strftime('%d %B %y') : _date
+    _date.present? && _date.instance_of ActiveSupport::TimeWithZone ? _date.strftime('%d %B %y') : _date
   end
 
   def file(page)

--- a/app/views/layouts/cms/_resource.html.erb
+++ b/app/views/layouts/cms/_resource.html.erb
@@ -1,7 +1,7 @@
 <div class="page--resource page-padding">
   <div class="container--medium">
     <p class="page__date">
-      <%= cms_fragment_content(:published_date, @cms_page).strftime('%d %B %y') %>
+      <%= cms_fragment_content_datetime(:published_date, @cms_page).strftime('%d %B %y') %>
     </p>
 
     <h1 class="page__h1"><%= @cms_page.label %></h1>

--- a/app/views/partials/cards/_articles.html.erb
+++ b/app/views/partials/cards/_articles.html.erb
@@ -14,7 +14,7 @@
     <% @items[:cards].each_with_index do |card, index| %>
       <listing-page-card-news
         key="<%= index %>"
-        date="<%= cms_fragment_content(:published_date, card).strftime('%d %B %y') %>"
+        date="<%= cms_fragment_content_datetime(:published_date, card).strftime('%d %B %y') %>"
         image="<%= cms_fragment_content(:image, card) %>"
         summary="<%= cms_fragment_content(:summary, card) %>"
         title="<%= card[:label].truncate(59, separator: ' ') %>"

--- a/config/initializers/comfy_patching.rb
+++ b/config/initializers/comfy_patching.rb
@@ -185,22 +185,4 @@ Rails.configuration.to_prepare do
       end
     end
   end
-
-  # More Comfy patching, now patching the old Comfy CMS Helper
-  Comfy::CmsHelper.module_eval do 
-    def cms_fragment_content(identifier, page = @cms_page)
-      frag = page&.fragments&.detect { |f| f.identifier == identifier.to_s }
-      return "" unless frag
-      case frag.tag
-      when "date", "datetime", "date_not_null" # date_not_null is our own custom CMS tag
-        frag.datetime
-      when "checkbox"
-        frag.boolean
-      when "file", "files"
-        frag.attachments
-      else
-        frag.content
-      end
-    end
-  end
 end

--- a/config/initializers/comfy_patching.rb
+++ b/config/initializers/comfy_patching.rb
@@ -185,4 +185,22 @@ Rails.configuration.to_prepare do
       end
     end
   end
+
+  # More Comfy patching, now patching the old Comfy CMS Helper
+  Comfy::CmsHelper.module_eval do 
+    def cms_fragment_content(identifier, page = @cms_page)
+      frag = page&.fragments&.detect { |f| f.identifier == identifier.to_s }
+      return "" unless frag
+      case frag.tag
+      when "date", "datetime", "date_not_null" # date_not_null is our own custom CMS tag
+        frag.datetime
+      when "checkbox"
+        frag.boolean
+      when "file", "files"
+        frag.attachments
+      else
+        frag.content
+      end
+    end
+  end
 end


### PR DESCRIPTION
Bug fix for staging, to allow the custom tag `date_not_null` to be properly sorted in the views as the Comfy helper `cms_fragment_content` is not properly configured to work with it (returns its content which is nil). 