### PR TITLE
Return empty string if attachment is missing

### DIFF
--- a/app/helpers/cms_helper.rb
+++ b/app/helpers/cms_helper.rb
@@ -167,7 +167,8 @@ module CmsHelper
   def linkify(url, fragment_link)
     # If it is a file as opposed to a link
     if fragment_link =~ /(file)/ 
-      file = @cms_page.fragments.find { |fragment| fragment.tag == 'file' }
+      file = @cms_page.fragments.find_by(tag: 'file')
+      return '' if file.attachments.first.blank?
       return rails_blob_path(file.attachments.first, disposition: 'attachment')
     end
     # TODO - add validations to Comfy pages controller to make it more robust 

--- a/app/helpers/cms_helper.rb
+++ b/app/helpers/cms_helper.rb
@@ -168,7 +168,7 @@ module CmsHelper
     # If it is a file as opposed to a link
     if fragment_link =~ /(file)/ 
       file = @cms_page.fragments.find_by(tag: 'file')
-      return '' if file.attachments.first.blank?
+      return '' if !file || file.attachments.first.blank?
       return rails_blob_path(file.attachments.first, disposition: 'attachment')
     end
     # TODO - add validations to Comfy pages controller to make it more robust 

--- a/app/helpers/cms_helper.rb
+++ b/app/helpers/cms_helper.rb
@@ -157,9 +157,7 @@ module CmsHelper
     resources = [
       get_resource(:resource_link_text, :resource_link_url, 'link', 'link-external'),
       get_resource(:resource_file_title, :resource_file, 'download', 'download')
-    ]
-
-    resources.map { |resource| resource unless resource == false }
+    ].compact
   end
 
   # Turns link[:url] value into a valid link if no http:// or https:// supplied
@@ -190,7 +188,7 @@ module CmsHelper
         url: linkify(cms_fragment_render(fragment_link, @cms_page), fragment_link)
       }
     else
-      false
+      nil
     end
   end
 


### PR DESCRIPTION
## Description

Fix 500 error when clicking on resources pages.
The error seems related to missing attachments still. Cleaning up the staging db more might help as well.
Here I'm returning an empty string instead if attachments are missing, which should be more future proof.