### PR TITLE
export date not null's datetime as content

### DIFF
--- a/config/initializers/comfy_patching.rb
+++ b/config/initializers/comfy_patching.rb
@@ -64,7 +64,7 @@ Rails.configuration.to_prepare do
         header = "#{frag.tag} #{frag.identifier}"
         content =
           case frag.tag
-          when "datetime", "date"
+          when "datetime", "date", "date_not_null"
             frag.datetime
           when "checkbox"
             frag.boolean


### PR DESCRIPTION
**Ticket**

https://unep-wcmc.codebasehq.com/projects/pp-refresh/tickets/190

Added `date_not_null` to the monkey patch, so that it uses `datetime` instead of `content`, which means that it should export its datetime to the `content.html` that it generates for each page.