### PR TITLE
Ensure OECM attributes can be set only if PA is an OECM area

### DIFF
--- a/app/models/protected_area.rb
+++ b/app/models/protected_area.rb
@@ -24,6 +24,8 @@ class ProtectedArea < ApplicationRecord
 
   after_create :create_slug
 
+  validate :oecm_attributes
+
   scope :all_except, -> (pa) { where.not(id: pa) }
 
   scope :oecms, -> { where(is_oecm: true) }
@@ -326,7 +328,10 @@ class ProtectedArea < ApplicationRecord
     )
   end
 
+  OECM_ATTRS_ERROR = "'conservation_objectives' and 'supplementary_info can only be assigned if this is an OECM area".freeze
+  def oecm_attributes
+    return if is_oecm
 
-
-
+    errors.add(:oecm_attributes, OECM_ATTRS_ERROR) if supplementary_info || conservation_objectives
+  end
 end

--- a/app/models/protected_area.rb
+++ b/app/models/protected_area.rb
@@ -328,7 +328,7 @@ class ProtectedArea < ApplicationRecord
     )
   end
 
-  OECM_ATTRS_ERROR = "'conservation_objectives' and 'supplementary_info can only be assigned if this is an OECM area".freeze
+  OECM_ATTRS_ERROR = "'conservation_objectives' and 'supplementary_info' can only be assigned if this is an OECM area".freeze
   def oecm_attributes
     return if is_oecm
 

--- a/app/presenters/protected_area_presenter.rb
+++ b/app/presenters/protected_area_presenter.rb
@@ -121,10 +121,24 @@ class ProtectedAreaPresenter
         title: 'International Criteria',
         value: protected_area.international_criteria || "Not Reported"
       }
-    ]
+    ].concat(oecm_attributes)
   end
   
   private
+
+  def oecm_attributes
+    return [] unless protected_area.is_oecm
+    [
+      {
+        title: 'Supplementary Information',
+        value: protected_area.supplementary_info
+      },
+      {
+        title: 'Conservation Objectives',
+        value: protected_area.conservation_objectives
+      }
+    ]
+  end
 
   def green_list_status_info
     return unless protected_area.green_list_status_id

--- a/lib/modules/download/queries.rb
+++ b/lib/modules/download/queries.rb
@@ -9,7 +9,8 @@ module Download
       :no_tk_area, :status, :status_yr,
       :gov_type, :own_type, :mang_auth,
       :mang_plan, :verif, :metadataid,
-      :sub_loc, :parent_iso3, :iso3
+      :sub_loc, :parent_iso3, :iso3,
+      :supp_info, :cons_obj #TODO Ensure these OECM attributes are working ok here
     ]
 
     POLYGONS_COLUMNS = POINTS_COLUMNS.clone

--- a/lib/modules/wdpa/data_standard.rb
+++ b/lib/modules/wdpa/data_standard.rb
@@ -25,7 +25,9 @@ class Wdpa::DataStandard
     :wkb_geometry => {name: :the_geom, type: :geometry, label: 'Geometry'},
     :metadataid   => {name: :sources, type: :integer, label: 'Source'},
     :own_type     => {name: :owner_type, type: :string, label: 'Owner Type'},
-    :pa_def       => {name: :is_oecm, type: :oecm, label: 'PA Def'}
+    :pa_def       => {name: :is_oecm, type: :oecm, label: 'PA Def'},
+    :supp_info    => {name: :supp_info, type: :string, label: 'Supplementary Info'},
+    :cons_obj     => {name: :cons_obj, type: :string, label: 'Conservation objectives'}
   }
 
   POLYGON_ATTRIBUTES = [


### PR DESCRIPTION
## Description

Amend model and importer to account for the new OECM attributes stored in the ProtectedAreas table

Related [DB PR](https://github.com/unepwcmc/protectedplanet-db/pull/41)