### PR TITLE
corrected OECMs on homepage fact cards to protected areas

### DIFF
--- a/app/presenters/home_presenter.rb
+++ b/app/presenters/home_presenter.rb
@@ -56,7 +56,7 @@ class HomePresenter
         totals: [
           {
             number: marine_pas,
-            text: I18n.t('global.area-types.oecm')
+            text: I18n.t('global.area-types.wdpa')
           }
         ]
       },


### PR DESCRIPTION
**Ticket**

https://unep-wcmc.codebasehq.com/projects/pp-refresh/tickets/205

Changed 'OECMs' on homepage's fact card component to read 'Protected Areas'