### PR TITLE
Exclude gl candidates

### DIFF
--- a/app/controllers/green_list_controller.rb
+++ b/app/controllers/green_list_controller.rb
@@ -22,7 +22,7 @@ class GreenListController < ApplicationController
     {
       title: I18n.t('charts.legend.number-pa'),
       units: I18n.t('charts.units.km2'),
-      datapoints: ProtectedArea.greenlist_coverage_growth(2000).map { |el| { year: el[0], value: el[1] } }
+      datapoints: ProtectedArea.greenlist_coverage_growth(2000)
     }.to_json 
     
     # TODO - This may need to be reworked by CLS

--- a/app/controllers/green_list_controller.rb
+++ b/app/controllers/green_list_controller.rb
@@ -12,7 +12,6 @@ class GreenListController < ApplicationController
   def index
     @download_options = helpers.download_options(['csv', 'shp', 'gdb'], 'general', 'greenlist')
 
-    # TODO - statistics are not accurate
     stats = green_list_statistics
     @pas_km = stats['green_list_area']
     @pas_percent = stats['green_list_perc']
@@ -27,7 +26,7 @@ class GreenListController < ApplicationController
     }.to_json 
     
     # TODO - This may need to be reworked by CLS
-    @total_area_percent = Stats::Global.percentage_pa_cover.to_f - @pas_percent.to_f
+    @total_area_percent = (Stats::Global.percentage_pa_cover - @pas_percent.to_f).round(2)
 
     @filters = {
       db_type: ['wdpa'],

--- a/app/controllers/green_list_controller.rb
+++ b/app/controllers/green_list_controller.rb
@@ -25,7 +25,6 @@ class GreenListController < ApplicationController
       datapoints: ProtectedArea.greenlist_coverage_growth(2000)
     }.to_json 
     
-    # TODO - This may need to be reworked by CLS
     @total_area_percent = (Stats::Global.percentage_pa_cover - @pas_percent.to_f).round(2)
 
     @filters = {

--- a/app/models/protected_area.rb
+++ b/app/models/protected_area.rb
@@ -43,6 +43,11 @@ class ProtectedArea < ApplicationRecord
     where.not(green_list_status_id: nil)
   }
 
+  scope :non_candidate_green_list_areas, -> {
+    includes(:green_list_status)
+    .where.not(green_list_statuses: {status: 'Candidate'}, green_list_status_id: nil)
+  }
+
   scope :most_protected_marine_areas, -> (limit) {
     where("gis_marine_area IS NOT NULL").
     order(gis_marine_area: :desc).limit(limit)
@@ -87,7 +92,7 @@ class ProtectedArea < ApplicationRecord
     # Takes an optional start year from which to start counting
     coverage_growth_hash = {}
 
-    areas = ProtectedArea.green_list_areas.where.not(legal_status_updated_at: nil)
+    areas = ProtectedArea.non_candidate_green_list_areas.where.not(legal_status_updated_at: nil)
     
     if start_year
       date_from_year = "#{start_year}-01-01 00:00:00".to_time 
@@ -307,7 +312,7 @@ class ProtectedArea < ApplicationRecord
     )
   end
 
-  OECM_ATTRS_ERROR = "'conservation_objectives' and 'supplementary_info' can only be assigned if this is an OECM area".freeze
+  # OECM_ATTRS_ERROR = "'conservation_objectives' and 'supplementary_info' can only be assigned if this is an OECM area".freeze
   def oecm_attributes
     return if is_oecm
 

--- a/app/models/protected_area.rb
+++ b/app/models/protected_area.rb
@@ -105,8 +105,8 @@ class ProtectedArea < ApplicationRecord
       # year = date.to_date.year
       coverage_growth_hash[date] ||= []
       
+      # TODO - Check that chart matches with black box data after re-import finishes on staging copy
       area_sum = areas.where("legal_status_updated_at <= ?", date).reduce(0) { |sum, x| sum + x.gis_area }
-      # p "#{date}: #{areas.where("legal_status_updated_at <= ?", date).map { |area| "#{area.name} #{area.gis_area}" }.join(',')}"
       coverage_growth_hash[date] = area_sum
     end
 

--- a/app/models/protected_area.rb
+++ b/app/models/protected_area.rb
@@ -88,29 +88,30 @@ class ProtectedArea < ApplicationRecord
   end
 
   def self.greenlist_coverage_growth(start_year = nil)
-    # Is in this format: {year: area, ...}
+    # Is in this format: [{year: year, value: area}...]
     # Takes an optional start year from which to start counting
-    areas = ProtectedArea.non_candidate_green_list_areas.where.not(legal_status_updated_at: nil)
+    growth = <<-SQL
+      SELECT DISTINCT ON(t.year) JSON_BUILD_OBJECT(
+        'year', t.year, 'value', t.area
+      ) AS data
+      FROM (
+        SELECT pa.legal_status_updated_at AS year,
+              SUM(pa.gis_area) OVER(ORDER BY pa.legal_status_updated_at) AS area
+        FROM protected_areas pa
+        JOIN green_list_statuses gls ON gls.id = pa.green_list_status_id
+        WHERE gls.status <> 'Candidate'
+        ORDER BY year
+      ) t
+      WHERE EXTRACT(YEAR FROM t.year) >= ?
+    SQL
     
-    sorted_dates = areas.pluck(:legal_status_updated_at).sort { |a,b| b <=> a }.uniq
+    result = ActiveRecord::Base.connection.execute(
+      ActiveRecord::Base.send(:sanitize_sql_array, [
+        growth, start_year
+      ])
+    )
 
-    if start_year
-      date_from_year = "#{start_year}-01-01 00:00:00".to_time 
-      sorted_dates.filter! { |date| date >= date_from_year }
-    end
-
-    coverage_growth_hash = {}
-
-    sorted_dates.each do |date|
-      # year = date.to_date.year
-      coverage_growth_hash[date] ||= []
-      
-      # TODO - Check that chart matches with black box data after re-import finishes on staging copy
-      area_sum = areas.where("legal_status_updated_at <= ?", date).reduce(0) { |sum, x| sum + x.gis_area }
-      coverage_growth_hash[date] = area_sum
-    end
-
-    coverage_growth_hash
+    result.map { |r| JSON.parse(r['data']) }
   end
 
   def sources_per_pa

--- a/app/models/protected_area.rb
+++ b/app/models/protected_area.rb
@@ -87,7 +87,7 @@ class ProtectedArea < ApplicationRecord
     green_list_status_id.present?
   end
 
-  def self.greenlist_coverage_growth(start_year = nil)
+  def self.greenlist_coverage_growth(start_year = 0)
     # Is in this format: [{year: year, value: area}...]
     # Takes an optional start year from which to start counting
     growth = <<-SQL

--- a/app/models/protected_area.rb
+++ b/app/models/protected_area.rb
@@ -105,6 +105,7 @@ class ProtectedArea < ApplicationRecord
       # year = date.to_date.year
       coverage_growth_hash[date] ||= []
       
+      # TODO - ask Ed how exactly the total GL area in the CSV is calculated...
       area_sum = areas.where("legal_status_updated_at <= ?", date).reduce(0) { |sum, x| sum + x.gis_area }
       coverage_growth_hash[date] = area_sum
     end

--- a/app/models/protected_area.rb
+++ b/app/models/protected_area.rb
@@ -105,7 +105,7 @@ class ProtectedArea < ApplicationRecord
       # year = date.to_date.year
       coverage_growth_hash[date] ||= []
       
-      # TODO - ask Ed how exactly the total GL area in the CSV is calculated...
+      # TODO - have a look at this again if the staging data is still different 
       area_sum = areas.where("legal_status_updated_at <= ?", date).reduce(0) { |sum, x| sum + x.gis_area }
       coverage_growth_hash[date] = area_sum
     end

--- a/app/models/protected_area.rb
+++ b/app/models/protected_area.rb
@@ -313,7 +313,7 @@ class ProtectedArea < ApplicationRecord
     )
   end
 
-  # OECM_ATTRS_ERROR = "'conservation_objectives' and 'supplementary_info' can only be assigned if this is an OECM area".freeze
+  OECM_ATTRS_ERROR = "'conservation_objectives' and 'supplementary_info' can only be assigned if this is an OECM area".freeze
   def oecm_attributes
     return if is_oecm
 

--- a/app/presenters/region_presenter.rb
+++ b/app/presenters/region_presenter.rb
@@ -130,7 +130,9 @@ class RegionPresenter
     # Group them by region
     countries_in_region = countries.select { |country| country.region == region }
 
-    countries_in_region.concat(region.countries.where.not(id: countries_in_region).take(10 - countries_in_region.length).to_a)
+    if countries_in_region.length < 10
+      countries_in_region.concat(region.countries.where.not(id: countries_in_region).take(10 - countries_in_region.length).to_a)
+    end
 
     all_gls = countries_in_region.map do |country|
       total_gl_area = country.protected_areas.green_list_areas.present? ? country.total_gl_coverage : 0

--- a/lib/data/seeds/green_list_sites.csv
+++ b/lib/data/seeds/green_list_sites.csv
@@ -1,114 +1,114 @@
 wdpaid,status,expiry_date
-306808,Green Listed,19-03-2024
-108125,Green Listed,27-01-2023
-83037,relisted,31-12-2023
-388659,relisted,19-03-2024
-662,relisted,31-12-2023
-4044,relisted,31-12-2023
-147297,relisted,31-12-2023
-555555490,Green Listed,27-10-2023
-659,Green Listed,19-03-2023
-330608,Green Listed,19-03-2024
-345942,Green Listed,31-12-2023
-345888,Green Listed,31-12-2023
-555547502,Green Listed,31-12-2023
-83268,Green Listed,31-12-2023
-6307,Green Listed,31-12-2023
-555555517,Green Listed,27-10-2023
-62735,Green Listed,19-03-2024
-303320,Green Listed,27-10-2023
-256,Candidate,
-555544085,Candidate,
-68137,Candidate,
-902497,Green Listed,31-12-2023
-555526767,Candidate,
-555542446,Candidate,
-17360,Candidate,
-555558374,Green Listed,31-12-2023
-365025,Candidate,
-17231,Green Listed,27-10-2023
-17709,Green Listed,31-12-2023
-168201,Candidate,
-555624365,Candidate,
-555539517,Candidate,
-303317,Green Listed,27-10-2023
-819,Candidate,
-20299,Candidate,
-26625,Candidate,
-63136,relisted,31-12-2024
-309970,relisted,31-12-2024
-354414,relisted,01-01-2024
-17744,Candidate,
-555624257,Candidate,
-555526032,Candidate,
-555526045,Candidate,
-555526036,Candidate,
-555526606,Candidate,
-15089,Candidate,
-555599909,Candidate,
-4114,Candidate,
-9782,Green Listed,31-12-2023
-555555499,relisted,27-10-2023
-311888,Candidate,
-303038,Candidate,
-303045,Candidate,
-61595,Candidate,
-303072,Candidate,
-10754,Green Listed,31-12-2019
-12223,Green Listed,31-12-2019
-13966,Green Listed,31-12-2019
-303552,Green Listed,31-12-2025
-902487,Green Listed,27-10-2023
-147283,Candidate,
-718,Green Listed,31-12-2019
-769,Green Listed,31-12-2019
-768,Green Listed,31-12-2019
-555525592,Candidate,
-143,Candidate,
-7873,Candidate,
-32674,Candidate,
-555697546,Candidate,
-7523,Candidate,
-721,Candidate,
-555555513,Candidate,
-62990,Candidate,
 10279,Candidate,
-306793_A,Candidate,
-306793_B,Candidate,
-306844_A,Candidate,
-06844_B,Candidate,
-1850_A,Candidate,
-1850_B,Candidate,
-306777,Candidate,
-306779,Candidate,
-555548807,Candidate,
-306780,Candidate,
-767,Candidate,
-555514399,Candidate,
-555525849,Candidate,
-555577562,Candidate,
-663,Candidate,
-95349,Candidate,
-6271,Candidate,
-106711,Candidate,
+15260,Candidate,
 18998,Candidate,
 62716,Candidate,
 3981,Candidate,
 15260,Candidate,
-147302,Candidate,
-555577562,Candidate,
-36534,Candidate,
-26654,Candidate,
-67860,Candidate,
-95996,Candidate,
-3014,Candidate,
-63642,Candidate,
-555637437,Candidate,
-64511,Candidate,
+10754,Green Listed,31-12-2019
+108125,Green Listed,27-01-2023
+12223,Green Listed,31-12-2019
 13165,Candidate,
+13966,Green Listed,31-12-2019
+143,In assessment,
+147283,Candidate,
+147297,Relisted,31-12-2023
+147302,Candidate,
+15089,Candidate,
+168201,Candidate,
+17231,Green Listed,27-10-2023
+17360,Candidate,
+17709,Green Listed,31-12-2023
+17744,Candidate,
+1850_A,Candidate,
+1850_B,Candidate,
 18805,Candidate,
-30697,Candidate,
-313091,Candidate,
-555582988,Candidate,
 18807,Candidate,
+20299,Candidate,
+256,Candidate,
+26625,Candidate,
+26654,Candidate,
+3014,Candidate,
+303038,Candidate,
+303045,Candidate,
+303072,Candidate,
+303317,Green Listed,27-10-2023
+303320,Green Listed,27-10-2023
+303552,Green Listed,31-12-2025
+306777,Candidate,
+306779,Candidate,
+306780,Candidate,
+306793_A,Candidate,
+306793_B,Candidate,
+306808,Green Listed,19-03-2024
+306844_A,Candidate,
+306844_B,Candidate,
+30697,Candidate,
+309970,Relisted,31-12-2024
+354414,Relisted,31-12-2024
+311888,Candidate,
+313091,Candidate,
+32674,Candidate,
+330608,Green Listed,19-03-2024
+345888,Green Listed,31-12-2023
+345942,Green Listed,31-12-2023
+365025,Candidate,
+36534,Candidate,
+388659,Relisted,19-03-2024
+4044,Relisted,31-12-2023
+4114,Candidate,
+555514399,Candidate,
+555525592,Candidate,
+555525849,Candidate,
+555526032,Candidate,
+555526036,Candidate,
+555526045,Candidate,
+555526606,Candidate,
+555526767,Candidate,
+555539517,Candidate,
+555542446,Candidate,
+555544085,Candidate,
+555547502,Green Listed,31-12-2023
+555548807,Candidate,
+555555490,Green Listed,27-10-2023
+555555499,Relisted,27-10-2023
+555555513,Candidate,
+555555517,Green Listed,27-10-2023
+555558374,Green Listed,31-12-2023
+555577562,Candidate,
+555577562,Candidate,
+555582988,Candidate,
+555599909,Candidate,
+555624257,Candidate,
+555624365,Candidate,
+555637437,Candidate,
+555697546,Candidate,
+61595,Candidate,
+6271,Candidate,
+62735,Green Listed,19-03-2024
+62990,Candidate,
+6307,Green Listed,31-12-2023
+63136,Relisted,31-12-2024
+63642,Candidate,
+64511,Candidate,
+659,Green Listed,19-03-2023
+662,Relisted,31-12-2023
+663,Candidate,
+67860,Candidate,
+68137,Candidate,
+718,Green Listed,31-12-2019
+721,Candidate,
+7523,Candidate,
+767,Candidate,
+768,Green Listed,31-12-2019
+769,Green Listed,31-12-2019
+7873,Candidate,
+819,Candidate,
+83037,Relisted,31-12-2023
+83268,Green Listed,31-12-2023
+902487,Green Listed,27-10-2023
+902497,Green Listed,31-12-2023
 915,Candidate,
+95349,Candidate,
+95996,Candidate,
+9782,Green Listed,31-12-2023


### PR DESCRIPTION
Candidate GL sites are now excluded from the GL coverage growth chart, so only GL and relisted sites are present, also there is a small fix for the 'top 10 per region' chart because a line in the method used to build the chart was erroring as there were more than 10 countries with GL sites in a particular region. That chart actually has fixes for it in another branch/PR, I didn't want to clutter this one. 