### PR TITLE
Redirect to search page if PA found by slug

### DIFF
--- a/app/controllers/protected_areas_controller.rb
+++ b/app/controllers/protected_areas_controller.rb
@@ -8,9 +8,12 @@ class ProtectedAreasController < ApplicationController
     
     @download_options = helpers.download_options(['csv', 'shp', 'gdb', 'pdf'], 'protected_area', id)
 
-    @protected_area = ProtectedArea.
-      where("slug = ? OR wdpa_id = ?", id, id.to_i).
-      first
+    # If found by slug, redirect to search page
+    # This is to overcome possible issues with PAs with same name/slug and different WDPA ID
+    pa = ProtectedArea.find_by(slug: id)
+    redirect_to search_areas_path(search_term: pa.name) and return if pa
+
+    @protected_area = ProtectedArea.find_by(wdpa_id: id.to_i)
 
     @protected_area or raise_404
 


### PR DESCRIPTION
## Description

Redirect to search page if PA is found by slug or render show page as usual if found by WDPA ID.
Raise 404 if PA is not found at all.

## Notes
[Codebase ticket](https://unep-wcmc.codebasehq.com/projects/pp-refresh/tickets/217)