### PR TITLE
Ticket 221

### DIFF
--- a/config/initializers/comfy_patching.rb
+++ b/config/initializers/comfy_patching.rb
@@ -21,6 +21,9 @@ Rails.configuration.to_prepare do
     after_save :assign_layout_categories
 
     def assign_layout_categories
+      # If database tables have not been created yet, return early and do nothing
+      # This happens during a migration generated prior to the creation of such tables
+      return unless ActiveRecord::Base.connection.table_exists? Comfy::Cms::LayoutsCategory.table_name
       # _categories = [{ tag_params: 'topics', tag_class: 'categories'}]
       _categories = self.content_tokens.select do |t|
         unless t.is_a?(Hash)

--- a/lib/tasks/cms_categories.rake
+++ b/lib/tasks/cms_categories.rake
@@ -12,4 +12,11 @@ namespace :cms_categories do
       end
     end
   end
+
+  task destroy: :environment do
+    Comfy::Cms::LayoutsCategory.destroy_all
+    Comfy::Cms::PagesCategory.detroy_all
+    Comfy::Cms::PageCategory.detroy_all
+    Comfy::Cms::LayoutCategory.destroy_all
+  end
 end

--- a/lib/tasks/cms_categories.rake
+++ b/lib/tasks/cms_categories.rake
@@ -15,8 +15,8 @@ namespace :cms_categories do
 
   task destroy: :environment do
     Comfy::Cms::LayoutsCategory.destroy_all
-    Comfy::Cms::PagesCategory.detroy_all
-    Comfy::Cms::PageCategory.detroy_all
+    Comfy::Cms::PagesCategory.destroy_all
+    Comfy::Cms::PageCategory.destroy_all
     Comfy::Cms::LayoutCategory.destroy_all
   end
 end


### PR DESCRIPTION
## Description

Fix issues related to CMS custom categories:

* Ensure categories related tables have been created before doing anything in the `after_save` method.
* Ensure categories data exist as soon as tables are created so that CMS seeds import works fine too. (See [related DB PR](https://github.com/unepwcmc/protectedplanet-db/pull/44) for this)

## Notes
[Related DB PR](https://github.com/unepwcmc/protectedplanet-db/pull/44)
[Codebase Ticket](https://unep-wcmc.codebasehq.com/projects/pp-refresh/tickets/221)