### PR TITLE
Remove redundant header for related countries and territories

### DIFF
--- a/app/views/partials/stats/_stats-related-countries.html.erb
+++ b/app/views/partials/stats/_stats-related-countries.html.erb
@@ -2,7 +2,6 @@
   <h2><%= t('stats.related-countries.title') %></h2>
 
   <% if country_children %>
-    <h3 class="stats__subtitle"><%= t('stats.related-countries.title-child') %></h3>
     <ul class="list--underline">
       <% country_children.each do |child| %>
         <li class="list__li">
@@ -15,7 +14,6 @@
   <% end %>
 
   <% if country_parent %>
-    <h3 class="stats__subtitle"><%= t('stats.related-countries.title-parent') %></h3>
     <ul class="list--underline">
       <li class="list__li">
         <span class="list__title"><%= country_parent['name'] %></span>


### PR DESCRIPTION
## Description

Remove redundant header for related countries and territories sections as described in the [codebase ticket](https://unep-wcmc.codebasehq.com/projects/pp-refresh/tickets/211)