### PR TITLE
Add net-scp gem for the staging importer task

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem 'rails-controller-testing'
 
 gem 'gdal', '~> 2.0'
 gem 'net-sftp'
+gem 'net-scp'
 #
 group :production, :staging do
 #  gem 'unicorn'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1349,6 +1349,7 @@ DEPENDENCIES
   minitest (~> 5.10, != 5.10.2)
   mocha (~> 1.0.0)
   neat
+  net-scp
   net-sftp
   nokogiri (~> 1.10.4)
   pg (~> 0.21)


### PR DESCRIPTION
## Description

This was mainly to add what was the only thing left in the refresh-copy branch that wasn't on refresh yet.
Added the net-scp gem which turned out to be necessary when running the staging CMS import task