### PR TITLE
adjust initial center location for oecm map

### DIFF
--- a/app/controllers/oecm_controller.rb
+++ b/app/controllers/oecm_controller.rb
@@ -22,6 +22,9 @@ class OecmController < ApplicationController
         { url: OECM_FEATURE_SERVER_LAYER_URL, isPoint: false }
       ]
     }
+    @map_options = {
+      map: { center: [-100,0] }
+    }
     @filters = { db_type: ['oecm'] }
   end
 

--- a/app/views/oecm/index.html.erb
+++ b/app/views/oecm/index.html.erb
@@ -15,6 +15,7 @@
 <%= render partial: "partials/tabs/tabs-thematic-area-database", locals: { 
   config_search: @config_search_areas,
   map: @map,
+  map_options: @map_options,
   tabs: @tabs
 } %>
 

--- a/app/views/partials/maps/_main.html.erb
+++ b/app/views/partials/maps/_main.html.erb
@@ -1,7 +1,7 @@
 <div class="map--main">
   <v-map-header title="<%= map_yml[:title] %>"></v-map-header>
   <v-map 
-    <% if local_assigns.has_key? :map_options && !map_options.nil? %>
+    <% if local_assigns.has_key?(:map_options) && !map_options.nil? %>
       :options="<%= map_options.to_json %>"
     <% end %>
     :services-for-point-query="<%= map[:point_query_services].to_json %>"

--- a/app/views/partials/maps/_main.html.erb
+++ b/app/views/partials/maps/_main.html.erb
@@ -1,6 +1,11 @@
 <div class="map--main">
   <v-map-header title="<%= map_yml[:title] %>"></v-map-header>
-  <v-map :services-for-point-query="<%= map[:point_query_services].to_json %>"></v-map>
+  <v-map 
+    <% if local_assigns.has_key? :map_options && !map_options.nil? %>
+      :options="<%= map_options.to_json %>"
+    <% end %>
+    :services-for-point-query="<%= map[:point_query_services].to_json %>"
+  ></v-map>
   <v-map-filters
     :is-hidden="<%= !!map[:areFiltersHidden] %>"
     :overlays="<%= map[:overlays].to_json %>"

--- a/app/views/partials/tabs/_tabs-thematic-area-database.html.erb
+++ b/app/views/partials/tabs/_tabs-thematic-area-database.html.erb
@@ -15,7 +15,7 @@
       <section class="map-section">
         <%= render partial: "partials/maps/main", locals: {
           map: map,
-          map_options: local_assigns.has_key? :map_options ? map_options : nil
+          map_options: local_assigns.has_key?(:map_options) ? map_options : nil
         } %>
       </section>
     </tab-target>

--- a/app/views/partials/tabs/_tabs-thematic-area-database.html.erb
+++ b/app/views/partials/tabs/_tabs-thematic-area-database.html.erb
@@ -14,7 +14,8 @@
 
       <section class="map-section">
         <%= render partial: "partials/maps/main", locals: {
-          map: map
+          map: map,
+          map_options: local_assigns.has_key? :map_options ? map_options : nil
         } %>
       </section>
     </tab-target>


### PR DESCRIPTION
This should centre the map on roughy mexico on the oecm page. Other maps should be unaffected. 

Worth checking the oecm, wdpa, marine and home pages to check there are no issues with undefined local variables etc.