### PR TITLE
Fix/og image urls

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -120,8 +120,8 @@ class ApplicationController < ActionController::Base
   end
 
   def set_host_for_local_storage
-    Rails.application.routes.default_url_options[:host] = request.base_url if Rails.application.config.active_storage.service == :local
+    Rails.application.routes.default_url_options[:host] = request.base_url
     # TODO Check why this is not set automatically
-    ActiveStorage::Current.host = request.base_url if Rails.application.config.active_storage.service == :local
+    # ActiveStorage::Current.host = request.base_url if Rails.application.config.active_storage.service == :local
   end
 end

--- a/lib/modules/comfy_opengraph.rb
+++ b/lib/modules/comfy_opengraph.rb
@@ -3,6 +3,7 @@
 # Helper class to set Opengraph meta-tags for use with Comfy CMS @cms_page's
 class ComfyOpengraph
   include Rails.application.routes.url_helpers
+  include ActionView::Helpers::AssetUrlHelper
   include Comfy::CmsHelper
 
   attr_accessor :mappings


### PR DESCRIPTION
## Description

Issues with host not being set when fetching images url came up again.
Also, `AssetUrlHelper` module needs to be included so to use the `image_path` method; not sure why this seemed to have worked without it before.

These changes have already been temporarily applied to the copy staging instance without deploying just to ensure it works.
Withouth these changes, pages like the marine page and the GL pages were throwing an exception.