### PR TITLE
Ticket 164

### DIFF
--- a/app/models/pame_evaluation.rb
+++ b/app/models/pame_evaluation.rb
@@ -204,6 +204,12 @@ class PameEvaluation < ApplicationRecord
         title: "Year of assessment",
         options: unique_year,
         type: 'multiple'
+      },
+      {
+        name: 'type',
+        title: 'Type',
+        options: ['Marine', 'Terrestrial'],
+        type: 'multiple'
       }
     ].to_json
   end


### PR DESCRIPTION
**Ticket**

https://unep-wcmc.codebasehq.com/projects/pp-refresh/tickets/164

Added Type filter to PAME page to allow filtering by either Marine or Terrestrial areas. Filtering carries over to CSV download 

Need to check that Marine filter incorporates coastal areas as well. 