### PR TITLE
Sidekiq fix

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -44,7 +44,7 @@ require 'whenever/capistrano'
 
 
 
-set :services, [:sidekiq_pp]
+set :services, [:pp_default, :pp_import ]
 require 'capistrano/service'
 
 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -30,6 +30,6 @@ set :keep_releases, 5
 set :passenger_restart_with_touch, false
 
 
-#namespace :deploy do
-#  after :publishing, 'service:sidekiq_pp:restart'
-#end
+namespace :deploy do
+  after :publishing, 'service:pp_default:restart, service:pp_import:restart'
+end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,7 +1,6 @@
 # config valid only for current version of Capistrano
 lock '3.11.0'
 
-#set :application, 'ProtectedPlanet'
 set :repo_url, 'git@github.com:unepwcmc/ProtectedPlanet.git'
 set :application, "ProtectedPlanet"
 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,8 +1,9 @@
 # config valid only for current version of Capistrano
 lock '3.11.0'
 
-set :application, 'ProtectedPlanet'
+#set :application, 'ProtectedPlanet'
 set :repo_url, 'git@github.com:unepwcmc/ProtectedPlanet.git'
+set :application, "ProtectedPlanet"
 
 set :deploy_user, 'wcmc'
 set :deploy_to, "/home/#{fetch(:deploy_user)}/#{fetch(:application)}"
@@ -31,5 +32,6 @@ set :passenger_restart_with_touch, false
 
 
 namespace :deploy do
-  after :publishing, 'service:pp_default:restart, service:pp_import:restart'
+  after :publishing, 'service:pp_default:restart'
+  after :publishing, 'service:pp_import:restart'
 end

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -1,5 +1,5 @@
 set :stage, :staging
-set :branch, "refresh-with-master"
+set :branch, "sidekiq-fix"
 
 server 'new-web-copy.pp-staging.linode.protectedplanet.net', user: 'wcmc', roles: %w{web app db}
 


### PR DESCRIPTION
This is designed to better handle sidekiq processes.  For it to work 2 systemd scripts will need to be installed on the server.  

These can then be run standalone by

sudo systemctl start pp_import.service
sudo systemctl stop pp_import.service
sudo systemctl restart pp_import.service

sudo systemctl start pp_default.service
sudo systemctl stop pp_default.service
sudo systemctl restart pp_default.service


These will also be restarted at the end of the deploy so that they should always point to the current folder

Currently monitoring is handled by nagios, but when we upgrade to sidekiq 6 this should automatically be handled by systemd watchdog service