### PR TITLE
social media previews

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -36,8 +36,7 @@ class ApplicationController < ActionController::Base
       'image:alt': t('meta.image_alt'),
       'image:height': t('meta.image_height'),
       'image:width': t('meta.image_width'),
-      'locale': 'en_GB',
-      'locale:alternate': "#{I18n.locale}_#{I18n.locale.upcase}"
+      'locale': 'en_GB'
     }
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,22 +22,28 @@ class ApplicationController < ActionController::Base
   def opengraph
     return if admin_path?
 
-    @opengraph ||= OpengraphBuilder.new({
-                                          'og': {
-                                            'site_name': t('meta.site.name'),
-                                            'title': t('meta.site.title'),
-                                            'description': t('meta.site.description'),
-                                            'url': request.url,
-                                            'type': 'website',
-                                            'image': URI.join(root_url, helpers.image_path(t('meta.image'))),
-                                            'image:alt': t('meta.image_alt'),
-                                            'locale': I18n.locale
-                                          },
-                                          'twitter': {
-                                            'site': t('meta.twitter.site'),
-                                            'creator': t('meta.twitter.creator')
-                                          }
-                                        })
+    @opengraph ||= OpengraphBuilder.new('og': og_tags, 'twitter': twitter_tags)
+  end
+
+  def og_tags
+    {
+      'site_name': t('meta.site.name'),
+      'title': t('meta.site.title'),
+      'description': t('meta.site.description'),
+      'url': request.url,
+      'type': 'website',
+      'image': URI.join(root_url, helpers.image_path(t('meta.image'))),
+      'image:alt': t('meta.image_alt'),
+      'locale': I18n.locale
+    }
+  end
+
+  def twitter_tags
+    {
+      'card': t('meta.twitter.card'),
+      'site': t('meta.twitter.site'),
+      'creator': t('meta.twitter.creator')
+    }
   end
 
   def default_url_options

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -36,7 +36,8 @@ class ApplicationController < ActionController::Base
       'image:alt': t('meta.image_alt'),
       'image:height': t('meta.image_height'),
       'image:width': t('meta.image_width'),
-      'locale': I18n.locale
+      'locale': 'en_GB',
+      'locale:alternate': "#{I18n.locale}_#{I18n.locale.upcase}"
     }
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -34,6 +34,8 @@ class ApplicationController < ActionController::Base
       'type': 'website',
       'image': URI.join(root_url, helpers.image_path(t('meta.image'))),
       'image:alt': t('meta.image_alt'),
+      'image:height': t('meta.image_height'),
+      'image:width': t('meta.image_width'),
       'locale': I18n.locale
     }
   end

--- a/config/locales/meta/en.yml
+++ b/config/locales/meta/en.yml
@@ -11,5 +11,6 @@ en:
     image_alt: >-
       Screenshot of the Protected Planet website
     twitter:
+      card: "summary_large_image"
       site: "@protectedplanet"
       creator: "@protectedplanet"

--- a/config/locales/meta/en.yml
+++ b/config/locales/meta/en.yml
@@ -10,6 +10,8 @@ en:
     image: social.png
     image_alt: >-
       Screenshot of the Protected Planet website
+    image_height: 630
+    image_width: 1200
     twitter:
       card: "summary_large_image"
       site: "@protectedplanet"

--- a/lib/modules/comfy_opengraph.rb
+++ b/lib/modules/comfy_opengraph.rb
@@ -71,12 +71,13 @@ class ComfyOpengraph
   end
 
   def og_image
-    image = URI.join(root_url, url_for(cms_fragment_render(:hero_image, @page)))
+    hero_image = cms_fragment_render(:hero_image, @page)
+    image = URI.join(root_url, url_for(hero_image))
     fallback_image = image_url(I18n.t('meta.image'))
-    image.blank? ? fallback_image : resize(image)
+    hero_image.blank? ? fallback_image : image                        
   end
 
-  def resize(image)
+  # def resize(image)
     #TODO - Get this working as we don't want to resize unnecessarily
     # Using FastImage as MiniMagick is way too slow
     # actual_image = MiniMagick::Image.open(local_url(image))
@@ -88,9 +89,9 @@ class ComfyOpengraph
 
     # In line with Twitter guidelines for maximum dimensions
     # IMPORTANT: takes an ActiveStorage attachment rather than a relative path to the image 
-    variant = image.variant(resize: "1200x630")
-    URI.join(root_url, rails_representation_path(variant, only_path: true))
-  end
+  #   variant = image.variant(resize: "1200x630")
+  #   URI.join(root_url, rails_representation_path(variant, only_path: true))
+  # end
 
   def og_title
     social_title = cms_fragment_content(:social_title, @page)

--- a/lib/modules/comfy_opengraph.rb
+++ b/lib/modules/comfy_opengraph.rb
@@ -71,8 +71,8 @@ class ComfyOpengraph
   end
 
   def og_image
-    image = @page.fragments.find_by(identifier: 'hero_image')&.attachments.first
-    fallback_image = URI.join(root_url, image_path(I18n.t('meta.image')))
+    image = URI.join(root_url, url_for(cms_fragment_render(:hero_image, @page)))
+    fallback_image = image_url(I18n.t('meta.image'))
     image.blank? ? fallback_image : resize(image)
   end
 

--- a/lib/modules/comfy_opengraph.rb
+++ b/lib/modules/comfy_opengraph.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'mini_magick'
+# require 'mini_magick'
 
 # Helper class to set Opengraph meta-tags for use with Comfy CMS @cms_page's
 class ComfyOpengraph
@@ -71,10 +71,10 @@ class ComfyOpengraph
   end
 
   def og_image
-    hero_image = cms_fragment_render(:hero_image, @page)
+    hero_image = @page.fragments.find_by(identifier: 'hero_image')&.attachments.first
     image = URI.join(root_url, url_for(hero_image))
     fallback_image = image_url(I18n.t('meta.image'))
-    hero_image.blank? ? fallback_image : image                        
+    hero_image.blank? ? fallback_image : image
   end
 
   # def resize(image)

--- a/lib/modules/comfy_opengraph.rb
+++ b/lib/modules/comfy_opengraph.rb
@@ -72,14 +72,13 @@ class ComfyOpengraph
 
   def og_image
     hero_image = @page.fragments.find_by(identifier: 'hero_image')&.attachments.first
-    image = URI.join(root_url, url_for(hero_image))
     fallback_image = image_url(I18n.t('meta.image'))
-    hero_image.blank? ? fallback_image : image
+    # hero_image.blank? ? fallback_image : resize(hero_image) # TODO - can't get S3 hosted images to display
+    fallback_image
   end
 
-  # def resize(image)
-    #TODO - Get this working as we don't want to resize unnecessarily
-    # Using FastImage as MiniMagick is way too slow
+  # TODO - Get this working as we don't want to resize unnecessarily
+  def resize(image)
     # actual_image = MiniMagick::Image.open(local_url(image))
 
     # # Return if image dimensions are sufficient
@@ -89,9 +88,9 @@ class ComfyOpengraph
 
     # In line with Twitter guidelines for maximum dimensions
     # IMPORTANT: takes an ActiveStorage attachment rather than a relative path to the image 
-  #   variant = image.variant(resize: "1200x630")
-  #   URI.join(root_url, rails_representation_path(variant, only_path: true))
-  # end
+    variant = image.variant(resize: "1200x630")
+    URI.join(root_url, rails_representation_path(variant, only_path: true))
+  end
 
   def og_title
     social_title = cms_fragment_content(:social_title, @page)

--- a/lib/modules/comfy_opengraph.rb
+++ b/lib/modules/comfy_opengraph.rb
@@ -71,7 +71,7 @@ class ComfyOpengraph
   end
 
   def og_image
-    image = Comfy::Cms::Fragment.find_by(identifier: 'image').attachments.first
+    image = Comfy::Cms::Fragment.find_by(identifier: 'hero_image')&.attachments.first
     fallback_image = URI.join(root_url, image_path(I18n.t('meta.image')))
     image.blank? ? fallback_image : resize(image)
   end

--- a/lib/modules/comfy_opengraph.rb
+++ b/lib/modules/comfy_opengraph.rb
@@ -88,7 +88,7 @@ class ComfyOpengraph
 
     # In line with Twitter guidelines for maximum dimensions
     # IMPORTANT: takes an ActiveStorage attachment rather than a relative path to the image 
-    variant = image.variant(size: '4096x4096')
+    variant = image.variant(size: '1200x638')
     URI.join(root_url, rails_representation_path(variant, only_path: true))
   end
 

--- a/lib/modules/comfy_opengraph.rb
+++ b/lib/modules/comfy_opengraph.rb
@@ -71,7 +71,7 @@ class ComfyOpengraph
   end
 
   def og_image
-    image = Comfy::Cms::Fragment.find_by(identifier: 'hero_image')&.attachments.first
+    image = @page.fragments.find_by(identifier: 'hero_image')&.attachments.first
     fallback_image = URI.join(root_url, image_path(I18n.t('meta.image')))
     image.blank? ? fallback_image : resize(image)
   end
@@ -88,7 +88,7 @@ class ComfyOpengraph
 
     # In line with Twitter guidelines for maximum dimensions
     # IMPORTANT: takes an ActiveStorage attachment rather than a relative path to the image 
-    variant = image.variant(size: '1200x638')
+    variant = image.variant(resize: "1200x630")
     URI.join(root_url, rails_representation_path(variant, only_path: true))
   end
 

--- a/lib/modules/comfy_opengraph.rb
+++ b/lib/modules/comfy_opengraph.rb
@@ -71,10 +71,9 @@ class ComfyOpengraph
   end
 
   def og_image
-    hero_image = @page.fragments.find_by(identifier: 'hero_image')&.attachments.first
-    fallback_image = image_url(I18n.t('meta.image'))
+    # hero_image = @page.fragments.find_by(identifier: 'hero_image')&.attachments.first
+    fallback_image = URI.join(root_url, image_url(I18n.t('meta.image')))
     # hero_image.blank? ? fallback_image : resize(hero_image) # TODO - can't get S3 hosted images to display
-    fallback_image
   end
 
   # TODO - Get this working as we don't want to resize unnecessarily

--- a/lib/modules/comfy_opengraph.rb
+++ b/lib/modules/comfy_opengraph.rb
@@ -55,8 +55,9 @@ class ComfyOpengraph
       return og_title
     when 'social-description'
       return og_description
-    when 'image'
-      return og_image
+    # TODO - can't get S3 hosted images to display
+    # when 'image'
+    #   return og_image
     else
       # expect a string by default
       fragment.content&.squish
@@ -65,16 +66,15 @@ class ComfyOpengraph
 
   def og_description
     social_desc = cms_fragment_content(:social_description, @page)
-    summary = cms_fragment_content(:summary, @page)
+    summary = cms_fragment_content(:summary, @page).delete("\n")
     fallback_summary = summary.blank? ? I18n.t('meta.site.description') : summary
     social_desc.blank? ? fallback_summary : social_desc
   end
 
   def og_image
-    # hero_image = @page.fragments.find_by(identifier: 'hero_image')&.attachments.first
-    fallback_image = URI.join(root_url, image_url(I18n.t('meta.image')))
-    # hero_image.blank? ? fallback_image : resize(hero_image) # TODO - can't get S3 hosted images to display
-    fallback_image
+    hero_image = @page.fragments.find_by(identifier: 'hero_image')&.attachments.first
+    fallback_image = URI.join(root_url, image_path(I18n.t('meta.image')))
+    hero_image.blank? ? fallback_image : resize(hero_image) 
   end
 
   # TODO - Get this working as we don't want to resize unnecessarily

--- a/lib/modules/comfy_opengraph.rb
+++ b/lib/modules/comfy_opengraph.rb
@@ -71,13 +71,10 @@ class ComfyOpengraph
   end
 
   def og_image
-<<<<<<< HEAD
     # hero_image = @page.fragments.find_by(identifier: 'hero_image')&.attachments.first
-=======
-    hero_image = @page.fragments.find_by(identifier: 'hero_image')&.attachments.first
->>>>>>> 8424894711a9d04f0eb20af0fc7dbc117046e902
     fallback_image = URI.join(root_url, image_url(I18n.t('meta.image')))
     # hero_image.blank? ? fallback_image : resize(hero_image) # TODO - can't get S3 hosted images to display
+    fallback_image
   end
 
   # TODO - Get this working as we don't want to resize unnecessarily

--- a/lib/modules/s3.rb
+++ b/lib/modules/s3.rb
@@ -11,17 +11,17 @@ class S3
     @client = Aws::S3::Client.new(region: Rails.application.secrets.s3_region)
   end
 
-  def self.upload object_name, file_path, opts={}
+  def self.upload(object_name, file_path, opts={})
     s3 = S3.new
     s3.upload object_name, file_path, opts
   end
 
-  def self.delete_all path
+  def self.delete_all(path)
     s3 = S3.new
-    s3.delete_all path
+    s3.delete_all(path)
   end
 
-  def self.link_to file_name, opts={for_import: false}
+  def self.link_to(file_name, opts={for_import: false})
     prefix = opts[:for_import] ? IMPORT_PREFIX : CURRENT_PREFIX
     prefixed_file_name = prefix + file_name
 
@@ -29,7 +29,7 @@ class S3
     URI.join(url, prefixed_file_name).to_s
   end
 
-  def upload object_name, source, opts
+  def upload(object_name, source, opts)
     # Default to downloads bucket unless specified (e.g. for when uploading CMS files)
     bucket = opts[:bucket] || Rails.application.secrets.aws_downloads_bucket
 
@@ -45,7 +45,7 @@ class S3
   end
 
 
-  def delete_all path
+  def delete_all(path)
     bucket = @s3.bucket(Rails.application.secrets.aws_downloads_bucket)
     objects = bucket.objects(prefix: path)
 


### PR DESCRIPTION
~~Set the Twitter card to use 'summary_large_image' and also use 4096 x 4096 (the maximum size) variants in case images are too large for Twitter~~

EDIT: After setting the staging S3 bucket to public-read, setting the Content-Type of the images and resizing the images, the S3 hosted hero images still cannot be loaded by the web crawlers used by the social media bots. I've resorted to using the default social image for all pages which can be shared - which as it turns out still doesn't work on the news pages for unknown reasons (the GL page and other thematic area pages work). There are still useful changes I've made so this should still be merged in. 

Also, apologies for the messy commit history, tried to amend commits after pushing (instead of before) 