### PR TITLE
Tweak autocomplete to also fetch countres and regions correctly

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -40,28 +40,14 @@ class SearchController < ApplicationController
   end
 
   def autocomplete
+    search_term = search_params[:search_term]
     db_type = search_params[:type]
-    @results = Autocompletion.lookup(search_params[:search_term], db_type, autocomplete_search_index(db_type))
+    index = search_params[:index]
 
-    render json: @results
-  end
-
-  private
-
-  def autocomplete_search_index db_type
-    case db_type
-      when 'country'
-        Search::COUNTRY_INDEX
-      when 'region'
-        Search::REGION_INDEX
-      when 'all'
-        Search::AREAS_INDEX
-      else
-        Search::PA_INDEX
-    end
+    render json: Autocompletion.lookup(search_term, db_type, index)
   end
 
   def search_params
-    params.permit(:search_term, :type, :requested_page, :items_per_page, :search_index, :filters)
+    params.permit(:search_term, :type, :index, :requested_page, :items_per_page, :search_index, :filters)
   end
 end

--- a/app/javascript/components/map/VMapPASearch.vue
+++ b/app/javascript/components/map/VMapPASearch.vue
@@ -68,7 +68,8 @@ export default {
         return new Promise((resolve, reject) => {
           axios.post('/search/autocomplete', {
             search_term: searchTerm,
-            type: this.type
+            type: this.type,
+            index: 'areas'
           })
             .then(response => {
               /**

--- a/lib/modules/autocompletion.rb
+++ b/lib/modules/autocompletion.rb
@@ -6,10 +6,19 @@ module Autocompletion
     'region' => :iso
   }.freeze
 
-  def self.lookup(term, db_type='wdpa', search_index=Search::PA_INDEX)
-    search = Search.search(term.downcase, get_filters(db_type), search_index)
+  def self.lookup(term, db_type='wdpa', search_index='sites')
+    search = Search.search(term.downcase, get_filters(db_type), Search::PA_INDEX)
 
     results = search.results.objects.values.compact.flatten
+
+    # TODO Workaround to also fetch countries and regions excluded by the db_type filter above.
+    # An ideal solution would be to use just one query and ignore the filter for documents that
+    # do not have the fields we are filtering by
+    if search_index && search_index != 'sites'
+      region_country_index = Search::COUNTRY_REGION_INDEX
+      search = Search.search(term.downcase, {}, region_country_index)
+      results.concat(search.results.objects.values.compact.flatten)
+    end
 
     # Count the number of items with the same name
     # and store it in an hash

--- a/lib/modules/autocompletion.rb
+++ b/lib/modules/autocompletion.rb
@@ -7,10 +7,7 @@ module Autocompletion
   }.freeze
 
   def self.lookup(term, db_type='wdpa', search_index='sites')
-    search = Search.search(term.downcase, get_filters(db_type), Search::PA_INDEX)
-
-    results = search.results.objects.values.compact.flatten
-
+    results = []
     # TODO Workaround to also fetch countries and regions excluded by the db_type filter above.
     # An ideal solution would be to use just one query and ignore the filter for documents that
     # do not have the fields we are filtering by
@@ -19,6 +16,9 @@ module Autocompletion
       search = Search.search(term.downcase, {}, region_country_index)
       results.concat(search.results.objects.values.compact.flatten)
     end
+
+    search = Search.search(term.downcase, get_filters(db_type), Search::PA_INDEX)
+    results.concat(search.results.objects.values.compact.flatten)
 
     # Count the number of items with the same name
     # and store it in an hash

--- a/lib/modules/search.rb
+++ b/lib/modules/search.rb
@@ -10,6 +10,7 @@ class Search
   PA_INDEX = "protectedareas_#{Rails.env}".freeze
   CMS_INDEX = "cms_#{Rails.env}".freeze
   AREAS_INDEX = [PA_INDEX, COUNTRY_INDEX, REGION_INDEX].join(',').freeze
+  COUNTRY_REGION_INDEX = [COUNTRY_INDEX, REGION_INDEX].join(',').freeze
   DEFAULT_INDEX_NAME = "#{AREAS_INDEX},#{CMS_INDEX}".freeze
   attr_reader :search_term, :options
 


### PR DESCRIPTION
## Description

This fixes the autocomplete in maps search and other pages search (e.g. WDPA, OECM, home page).

Honestly it's not the solution I was looking for, but after spending some time trying to tweak elasticsearch and failing, this was probably the quickest solution.
I've added a comment about this to remember and research other solution (probably separating the indexes or similar)