### PR TITLE
Fix to stop Googlebot from indexing PDF files

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -21,3 +21,7 @@ Disallow: /
 
 User-agent: Slurp
 Crawl-delay: 30
+
+User-agent: *
+Disallow: /*.pdf$
+


### PR DESCRIPTION
Fix for problem where Googlebot indexes PDF files but closes the connection before the PDF file has been generated.  

66.249.79.241 - - [07/Oct/2020:09:25:30 +0100] "GET /555610076.pdf HTTP/1.1" 499 0 "-" "Googlebot/2.1 (+http://www.google.com/bot.html)"
66.249.79.243 - - [07/Oct/2020:09:30:50 +0100] "GET /555518707.pdf HTTP/1.1" 499 0 "-" "Googlebot/2.1 (+http://www.google.com/bot.html)"

"last_data_send_time" : null,
               "method" : "GET",
               "next_request_early_read_error" : "The client connection is closed before the request is done processing (errno=-1020)",
               "path" : "/160904.pdf",
               "refcount" : 1,
               "request_body_already_read" : 0,
               "request_body_fully_read" : true,
               "request_body_type" : "NO_BODY",
               "response_begun" : false,
               "session" : {
                  "gupid" : "1976c9a-N6BKVgxQKF",
                  "pid" : 18586
               },
               "session_checkout_try" : 1,


This causes passenger sessions to eventually fill up and nginx to restart as no more requests can be processed.