### PR TITLE
Fix site with no country

### DIFF
--- a/app/controllers/protected_areas_controller.rb
+++ b/app/controllers/protected_areas_controller.rb
@@ -130,7 +130,7 @@ class ProtectedAreasController < ApplicationController
     if area.is_transboundary
       search_areas_path(filters: { special_status: ['is_transboundary'] })
     else
-      search_areas_path(filters: { location: { type: 'site', options: ["#{@countries.first.name}"] } })
+      search_areas_path(filters: { location: { type: 'country', options: ["#{@countries.first.name}"] } })
     end
   end
 end

--- a/app/controllers/protected_areas_controller.rb
+++ b/app/controllers/protected_areas_controller.rb
@@ -130,7 +130,8 @@ class ProtectedAreasController < ApplicationController
     if area.is_transboundary
       search_areas_path(filters: { special_status: ['is_transboundary'] })
     else
-      search_areas_path(filters: { location: { type: 'country', options: ["#{@countries.first.name}"] } })
+      location_filter = @countries.present? ? { location: { type: 'country', options: ["#{@countries.first.name}"] } } : {}
+      search_areas_path(filters: location_filter)
     end
   end
 end


### PR DESCRIPTION
## Description

Sites can have no countries attached apparently.
This means that the view all button should redirect to search page with all areas instead of throwing an exception.

Also, the 'view all' button was not taking into consideration the country correctly as well. This has also been fixed.

## Notes

[Codebase ticket](https://unep-wcmc.codebasehq.com/projects/protected-planet-support-and-maintenance/tickets/159)