### PR TITLE
Add rake task to reindex only the CMS

### DIFF
--- a/lib/tasks/search.rake
+++ b/lib/tasks/search.rake
@@ -10,4 +10,18 @@ namespace :search do
 
     logger.info "Reindex complete."
   end
+
+  namespace :cms do
+    desc 'Reindex CMS search'
+    task reindex: :environment do
+      logger = Logger.new(STDOUT)
+
+      logger.info "Deleting index..."
+      Search::Index.delete([Search::CMS_INDEX])
+      logger.info "Populating index..."
+      Search::Index.create_cms_fragments
+
+      logger.info "Reindex complete."
+    end
+  end
 end


### PR DESCRIPTION
## Description

Add rake task to reindex only the CMS.
This is useful so that the scheduled job that runs every night only reindexes the CMS instead of the whole thing.
The CMS is the only thing that could change potentially every day.

The idea is that after this is merged we can change the scheduled job to run:
``` bundle exec rake search:cms:reindex```
instead of:
``` bundle exec rake search:reindex```