### PR TITLE
stats now aligned on homepage and mpa page

### DIFF
--- a/app/controllers/marine_controller.rb
+++ b/app/controllers/marine_controller.rb
@@ -26,9 +26,9 @@ class MarineController < ApplicationController
       RegionPresenter.new(region).marine_coverage
     end
 
-    @pas_km = @marine_statistics['total_ocean_area_oecms_pas']
-    @pas_percent = @marine_statistics['total_ocean_oecms_pas_coverage_percentage']
-    @pas_total = @marine_statistics['total_marine_oecms_pas']
+    @pas_km = @marine_statistics['total_ocean_area_protected']
+    @pas_percent = @marine_statistics['total_ocean_pa_coverage_percentage']
+    @pas_total = @marine_statistics['total_marine_protected_areas']
     @map = {
       overlays: MapOverlaysSerializer.new(marine_overlays, map_yml).serialize,
       title: I18n.t('map.title'),

--- a/app/presenters/home_presenter.rb
+++ b/app/presenters/home_presenter.rb
@@ -4,25 +4,19 @@ class HomePresenter
   def initialize
   end
 
-  # Number of areas is still taken from the imported database rather than the global stats CSV.
-  # This is because we select out some sites for coverage stats so the number in the
-  # global stats csv is the number of the sites we use to calculate the coverage numbers beneath it.
   def terrestrial_pas
-    @terrestrial_pas ||= number_with_delimiter(ProtectedArea.where(marine: false).count)
+    @terrestrial_pas ||= number_with_delimiter(GlobalStatistic.total_terrestrial_protected_areas)
   end
   
   def marine_pas
     @marine_pas ||= number_with_delimiter(GlobalStatistic.total_marine_protected_areas)
   end
 
-  # TEMPORARILY USING CSV DATA FOR OECM NUMBERS - if importer manages to successfully populate OECMs, we'll go with that instead
   def terrestrial_oecms
-    # number_with_delimiter(ProtectedArea.where(marine: false, is_oecm: true).count)
     GlobalStatistic.total_terrestrial_oecms
   end
 
   def marine_oecms
-    # number_with_delimiter(ProtectedArea.where(marine: true, is_oecm: true).count)
     GlobalStatistic.total_marine_oecms
   end
 

--- a/app/presenters/home_presenter.rb
+++ b/app/presenters/home_presenter.rb
@@ -12,7 +12,7 @@ class HomePresenter
   end
   
   def marine_pas
-    @marine_pas ||= number_with_delimiter(ProtectedArea.where(marine: true).count)
+    @marine_pas ||= number_with_delimiter(GlobalStatistic.total_marine_protected_areas)
   end
 
   # TEMPORARILY USING CSV DATA FOR OECM NUMBERS - if importer manages to successfully populate OECMs, we'll go with that instead


### PR DESCRIPTION
**Ticket**

https://unep-wcmc.codebasehq.com/projects/protected-planet-support-and-maintenance/tickets/176

Statistics are now aligned on the homepage cards and the MPA page. The MPA page now no longer takes OECMs into account in the statistics, just PAs. Likewise, the number of marine protected areas on the homepage (excluding OECMs) now uses `GlobalStatistic` to populate it, as opposed to performing a query on the ProtectedArea model. 