### PR TITLE
fix/homepage-news-links

### DIFF
--- a/app/views/partials/cards/_articles.html.erb
+++ b/app/views/partials/cards/_articles.html.erb
@@ -18,7 +18,7 @@
         image="<%= cms_fragment_render(:image, card) %>"
         summary="<%= cms_fragment_content(:summary, card) %>"
         title="<%= card[:label].truncate(59, separator: ' ') %>"
-        url="<%= card[:url] %>"
+        url="<%= card[:full_path] %>"
       ></listing-page-card-news>
     <% end %>
   </div>


### PR DESCRIPTION
**Ticket**

https://unep-wcmc.codebasehq.com/projects/protected-planet-support-and-maintenance/tickets/184

Fixed news articles card links on the homepage so that they work again.