### PR TITLE
fix/invoke rails:cache:clear post-deploy:finishing

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,5 +1,5 @@
 # config valid only for current version of Capistrano
-lock '3.14.1'
+lock '3.11.0'
 
 set :repo_url, 'git@github.com:unepwcmc/ProtectedPlanet.git'
 set :application, "ProtectedPlanet"

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,5 +1,5 @@
 # config valid only for current version of Capistrano
-lock '3.11.0'
+lock '3.14.1'
 
 set :repo_url, 'git@github.com:unepwcmc/ProtectedPlanet.git'
 set :application, "ProtectedPlanet"
@@ -33,4 +33,5 @@ set :passenger_restart_with_touch, false
 namespace :deploy do
   after :publishing, 'service:pp_default:restart'
   after :publishing, 'service:pp_import:restart'
+  after :finishing, 'cache:clear'
 end

--- a/lib/tasks/cache.rake
+++ b/lib/tasks/cache.rake
@@ -1,5 +1,5 @@
 namespace :cache do
-  desc "Clear the Rails cache (Home page, PA Page)"
+  desc "Clear the Rails cache (everything except downloads which is handled by Redis)"
   task clear: :environment do
     logger = Logger.new(STDOUT)
 


### PR DESCRIPTION
**Ticket**

https://unep-wcmc.codebasehq.com/projects/protected-planet-support-and-maintenance/tickets/185

This should hopefully solve all the issues regarding missing content on pages that often occurs after a deploy. Turns out that there was already an old Rake task for clearing the Rails cache, all I've done is add it as a callback to the deploy:publishing hook. 

I've checked and `Rails.cache.clear` does not clear the Redis cache, either directly through the console, checking both the Redis keys and manually through checking the downloads on the website itself before, during and after clearing the cache. I'm not 100% sure, but I think this means that the downloads are safe and shouldn't be reset. 