### PR TITLE
Ticket 188 downloads name

### DIFF
--- a/app/controllers/pame_controller.rb
+++ b/app/controllers/pame_controller.rb
@@ -7,15 +7,14 @@ class PameController < ApplicationController
     filters: []
   }.to_json
 
-  # Format for this date is: Month and Year (4 digits)
-  UPDATED_AT = "July 2019".freeze
+  # Format for this date is: Year-MON (4 digits-3 chars)
+  UPDATED_AT = "2020-DEC".freeze
 
   def index
     @table_attributes = PameEvaluation::TABLE_ATTRIBUTES.to_json
     @filters = PameEvaluation.filters_to_json
     @sources = PameEvaluation.sources_to_json
     @json = PameEvaluation.paginate_evaluations(DEFAULT_PARAMS).to_json
-    @updated_at = UPDATED_AT
 
     @tabs = get_tabs(4).to_json
   end
@@ -30,7 +29,7 @@ class PameController < ApplicationController
     send_data PameEvaluation.to_csv(params.to_json), {
                 type: "text/csv; charset=utf-8; header=present",
                 disposition: "attachment",
-                filename: "protectedplanet-pame.csv" }
+                filename: "protectedplanet-pame-#{UPDATED_AT}.csv" }
   end
 end
 

--- a/app/javascript/components/forms/DownloadCsv.vue
+++ b/app/javascript/components/forms/DownloadCsv.vue
@@ -43,6 +43,10 @@
 
         axios.post('/pame/download', data, config)
           .then((response) => {
+            // content-disposition looks something like: 'attachment; filename="the_file_name_here.csv"
+            // so splitting the string by 'filename=" will leave us with ['attachemnt;', 'the_file_name_here.csv"']
+            // we then get the last item and split it further by the the remaining '"' to ensure anything after that is gone.
+            // Finally we get the first element of that split.
             const filename = response.headers['content-disposition'].split('filename\="')[1].split('\"')[0]
 
             this.createBlob(filename, response.data)

--- a/app/javascript/components/forms/DownloadCsv.vue
+++ b/app/javascript/components/forms/DownloadCsv.vue
@@ -43,8 +43,7 @@
 
         axios.post('/pame/download', data, config)
           .then((response) => {
-            const date = new Date().toJSON().slice(0,10),
-              filename = `protectedplanet-pame-${date}.csv`
+            const filename = response.headers['content-disposition'].split('filename\="')[1].split('\"')[0]
 
             this.createBlob(filename, response.data)
 

--- a/lib/modules/download/generators/base.rb
+++ b/lib/modules/download/generators/base.rb
@@ -88,7 +88,11 @@ class Download::Generators::Base
   end
 
   def sources_path
-    File.join(File.dirname(zip_path), "WDPA_sources.csv")
+    File.join(File.dirname(zip_path), "WDPA_sources_#{current_wdpa_id}.csv")
+  end
+
+  def current_wdpa_id
+    Wdpa::S3.current_wdpa_identifier
   end
 
   def add_sources

--- a/lib/modules/download/generators/gdb.rb
+++ b/lib/modules/download/generators/gdb.rb
@@ -8,7 +8,7 @@ class Download::Generators::Gdb < Download::Generators::Base
       select: Download::Utils.download_columns(reject: [:gis_area, :gis_m_area]),
       where: %{"TYPE" = 'Point'}
     }
-  }
+  }.freeze
 
   def initialize zip_path, wdpa_ids
     @path = File.dirname(zip_path)

--- a/lib/modules/download/generators/gdb.rb
+++ b/lib/modules/download/generators/gdb.rb
@@ -38,7 +38,7 @@ class Download::Generators::Gdb < Download::Generators::Base
   private
 
   def export_component name, props
-    component_path = gdb_component(name)
+    component_path = gdb_component
     view_name = create_view query(props[:select], props[:where])
 
     return [] if ActiveRecord::Base.connection.select_value("""
@@ -70,17 +70,15 @@ class Download::Generators::Gdb < Download::Generators::Base
   end
 
   def clean_up
-    QUERY_CONDITIONS.each do |name, _|
-      FileUtils.rm_rf gdb_component(name)
-    end
+    FileUtils.rm_rf gdb_component
   end
 
   def zip_path
     File.join(@path, "#{@filename}.zip")
   end
 
-  def gdb_component(name)
-    File.join(@path, "#{@filename}_#{name}.gdb")
+  def gdb_component
+    File.join(@path, "#{@filename}.gdb")
   end
 
   def gdb_filenames(gdb_paths)

--- a/lib/modules/download/generators/gdb.rb
+++ b/lib/modules/download/generators/gdb.rb
@@ -26,7 +26,7 @@ class Download::Generators::Gdb < Download::Generators::Base
 
       export_sources
 
-      system("zip -r #{zip_path} #{gdb_component}", chdir: @path) and add_attachments
+      system("zip -r #{zip_path} #{gdb_filename}", chdir: @path) and add_attachments
     end
   rescue Ogr::Postgres::ExportError
     return false
@@ -85,5 +85,9 @@ class Download::Generators::Gdb < Download::Generators::Base
 
   def gdb_component
     File.join(@path, "#{@filename}.gdb")
+  end
+
+  def gdb_filename
+    gdb_component.split('/').last
   end
 end

--- a/lib/modules/download/generators/gdb.rb
+++ b/lib/modules/download/generators/gdb.rb
@@ -19,17 +19,14 @@ class Download::Generators::Gdb < Download::Generators::Base
   def generate
     return false if @wdpa_ids.is_a?(Array) && @wdpa_ids.empty?
 
-    gdb_paths = []
-
     clean_up_after do
       QUERY_CONDITIONS.each do |name, props|
-        gdb_paths << export_component(name, props)
+        export_component(name, props)
       end
 
       export_sources
 
-      #system("zip -ru #{zip_path} #{File.basename(sources_path)}", chdir: File.dirname(sources_path))
-      system("zip -r #{zip_path} #{gdb_filenames(gdb_paths)}", chdir: @path) and add_attachments
+      system("zip -r #{zip_path} #{gdb_component}", chdir: @path) and add_attachments
     end
   rescue Ogr::Postgres::ExportError
     return false
@@ -88,9 +85,5 @@ class Download::Generators::Gdb < Download::Generators::Base
 
   def gdb_component
     File.join(@path, "#{@filename}.gdb")
-  end
-
-  def gdb_filenames(gdb_paths)
-    gdb_paths.flatten.compact.uniq.map { |p| p.split('/').last }.join(' ')
   end
 end

--- a/lib/modules/download/generators/gdb.rb
+++ b/lib/modules/download/generators/gdb.rb
@@ -28,7 +28,7 @@ class Download::Generators::Gdb < Download::Generators::Base
 
       export_sources
 
-      system("zip -ru #{zip_path} #{File.basename(sources_path)}", chdir: File.dirname(sources_path))
+      #system("zip -ru #{zip_path} #{File.basename(sources_path)}", chdir: File.dirname(sources_path))
       system("zip -r #{zip_path} #{gdb_filenames(gdb_paths)}", chdir: @path) and add_attachments
     end
   rescue Ogr::Postgres::ExportError
@@ -60,6 +60,15 @@ class Download::Generators::Gdb < Download::Generators::Base
     query = "SELECT #{select}"
     query << " FROM #{Wdpa::Release::DOWNLOADS_VIEW_NAME}"
     add_conditions(query, conditions).squish
+  end
+
+  def export_sources
+    _query = <<-SQL
+      SELECT #{Download::Utils.source_columns}
+      FROM standard_sources
+    SQL
+
+    Ogr::Postgres.export(:gdb, gdb_component, _query, 'source')
   end
 
   def clean_up_after

--- a/lib/modules/download/generators/shapefile.rb
+++ b/lib/modules/download/generators/shapefile.rb
@@ -11,7 +11,7 @@ class Download::Generators::Shapefile < Download::Generators::Base
       select: Download::Utils.download_columns(reject: [:gis_area, :gis_m_area]),
       where: %{"TYPE" = 'Point'}
     }
-  }
+  }.freeze
 
   def initialize zip_path, wdpa_ids, number_of_pieces=3
     @path = File.dirname(zip_path)

--- a/lib/modules/download/generators/shapefile.rb
+++ b/lib/modules/download/generators/shapefile.rb
@@ -93,8 +93,7 @@ class Download::Generators::Shapefile < Download::Generators::Base
   end
 
   def zip_path(index='')
-    _filename = @filename
-    _filename << "_#{index}" if index.present?
+    _filename = index.present? ? "#{@filename}_#{index}" : @filename
     File.join(@path, "#{_filename}.zip")
   end
 

--- a/lib/modules/download/generators/shapefile.rb
+++ b/lib/modules/download/generators/shapefile.rb
@@ -17,7 +17,8 @@ class Download::Generators::Shapefile < Download::Generators::Base
     @path = File.dirname(zip_path)
     @filename = File.basename(zip_path, File.extname(zip_path))
     @wdpa_ids = wdpa_ids
-    @number_of_pieces = number_of_pieces
+    # If there are 2 areas involved max, generate just one shp
+    @number_of_pieces = (wdpa_ids.size > 2 || wdpa_ids.blank?) ? number_of_pieces : 1
   end
 
   def generate

--- a/lib/modules/download/generators/shapefile.rb
+++ b/lib/modules/download/generators/shapefile.rb
@@ -93,7 +93,9 @@ class Download::Generators::Shapefile < Download::Generators::Base
   end
 
   def zip_path(index='')
-    File.join(@path, "#{@filename}_#{index}.zip")
+    _filename = @filename
+    _filename << "_#{index}" if index.present?
+    File.join(@path, "#{_filename}.zip")
   end
 
   def shapefile_components name

--- a/lib/modules/download/generators/shapefile.rb
+++ b/lib/modules/download/generators/shapefile.rb
@@ -93,7 +93,7 @@ class Download::Generators::Shapefile < Download::Generators::Base
   end
 
   def zip_path(index='')
-    File.join(@path, "#{@filename}#{index}.zip")
+    File.join(@path, "#{@filename}_#{index}.zip")
   end
 
   def shapefile_components name

--- a/lib/modules/download/utils.rb
+++ b/lib/modules/download/utils.rb
@@ -65,7 +65,7 @@ module Download
       current_wdpa_id = Wdpa::S3.current_wdpa_identifier
 
       "#{basename}_#{current_wdpa_id}_Public".tap do |base_filename|
-        base_filename << "_#{identifier}" if domain == 'search'
+        base_filename << "_#{identifier}" if needs_identifier_suffix?(domain, identifier)
         base_filename << "_#{format}" if format.present? && format != 'gdb'
       end
     end
@@ -81,6 +81,11 @@ module Download
 
     def self.search_token term, filters
       Digest::SHA256.hexdigest(term.to_s + filters_dump(filters))
+    end
+
+    def self.needs_identifier_suffix?(domain, identifier)
+      return true if %w(search protected_area pdf).include?(domain)
+      !BASENAMES.keys.include?(identifier)
     end
   end
 end

--- a/lib/modules/download/utils.rb
+++ b/lib/modules/download/utils.rb
@@ -54,11 +54,20 @@ module Download
       end
     end
 
+    BASENAMES = {
+      'wdpa' => 'WDPA',
+      'oecm' => 'WDOECM',
+      'default' => 'WDPA_WDOECM'
+    }.freeze
+    # identifier is the search token if domain is search
     def self.filename domain, identifier, format
-      "WDPA_#{Wdpa::S3.current_wdpa_identifier}".tap { |base_filename|
-        base_filename << "_#{domain}"     if domain != 'general'
-        base_filename << "_#{identifier}_#{format}" if (identifier != 'all' && identifier.present?)
-      }
+      basename = BASENAMES[identifier] || BASENAMES['default']
+      current_wdpa_id = Wdpa::S3.current_wdpa_identifier
+
+      "#{basename}_#{current_wdpa_id}_Public".tap do |base_filename|
+        base_filename << "_#{identifier}" if domain == 'search'
+        base_filename << "_#{format}" if format.present? && format != 'gdb'
+      end
     end
 
     def self.extract_filters filters
@@ -67,7 +76,7 @@ module Download
     end
 
     def self.filters_dump filters
-      filters_dump = Marshal.dump filters.to_hash.sort.to_json
+      Marshal.dump filters.to_hash.sort.to_json
     end
 
     def self.search_token term, filters

--- a/lib/modules/ogr/command_templates/postgres_gdb_export.erb
+++ b/lib/modules/ogr/command_templates/postgres_gdb_export.erb
@@ -1,5 +1,5 @@
 ogr2ogr 
-<%= if needs_updating %>
+<% if needs_updating %>
   -update
 <% end %>
 -skipfailures

--- a/lib/modules/ogr/command_templates/postgres_gdb_export.erb
+++ b/lib/modules/ogr/command_templates/postgres_gdb_export.erb
@@ -1,4 +1,4 @@
-ogr2ogr -skipfailures
+ogr2ogr -update -skipfailures
 -f "FileGDB"
 <%= file_name %>
 PG:"host=<%= db_config[:host] %>

--- a/lib/modules/ogr/command_templates/postgres_gdb_export.erb
+++ b/lib/modules/ogr/command_templates/postgres_gdb_export.erb
@@ -12,5 +12,7 @@ PG:"host=<%= db_config[:host] %>
   <% end %>
   dbname=<%= db_config[:database] %>"
 -sql "<%= query %>"
--nlt "<%= geom_type.upcase %>"
+<% unless geom_type == 'source' %>
+  -nlt "<%= geom_type.upcase %>"
+<% end %>
 -nln "<%= feature_name %>"

--- a/lib/modules/ogr/command_templates/postgres_gdb_export.erb
+++ b/lib/modules/ogr/command_templates/postgres_gdb_export.erb
@@ -9,4 +9,4 @@ PG:"host=<%= db_config[:host] %>
   dbname=<%= db_config[:database] %>"
 -sql "<%= query %>"
 -nlt "<%= geom_type.upcase %>"
--nln "<%= file_name.split('/').last[0..-5] %>"
+-nln "<%= feature_name %>"

--- a/lib/modules/ogr/command_templates/postgres_gdb_export.erb
+++ b/lib/modules/ogr/command_templates/postgres_gdb_export.erb
@@ -1,4 +1,8 @@
-ogr2ogr -update -skipfailures
+ogr2ogr 
+<%= if needs_updating %>
+  -update
+<% end %>
+-skipfailures
 -f "FileGDB"
 <%= file_name %>
 PG:"host=<%= db_config[:host] %>

--- a/lib/modules/ogr/postgres.rb
+++ b/lib/modules/ogr/postgres.rb
@@ -22,6 +22,7 @@ class Ogr::Postgres
 
   def self.export file_type, file_name, query, geom_type='polygon'
     template = file_type == :gdb ? TEMPLATES[:gdb_export] : TEMPLATES[:export]
+    needs_updating = File.exist?(file_name)
     feature_name = get_feature_name(file_name, geom_type)
     system ogr_command(template, binding)
   end

--- a/lib/modules/ogr/postgres.rb
+++ b/lib/modules/ogr/postgres.rb
@@ -70,11 +70,14 @@ class Ogr::Postgres
     # Given the original filename should also contains 'polygons' or 'points' at the end,
     # we remove this bit.
     attrs.pop if %w(polygons points).include?(attrs[-1])
+    # If the filename does not end with 'Public' it means there's also an identifier (e.g. an ISO or a WDPA ID)
+    # So the original filename would have been something like WDPA_MmmYYY_Public_identifier
+    identifier = attrs.pop unless attrs[-1].downcase == 'public'
     # Replace 'Public' with the geometry type formatted correctly, e.g. => ['WDPA', 'MmmYYY', 'poly']
     attrs[-1] = FEATURE_TYPES[geom_type]
     # Swap date and geometry type, e.g. => ['WDPA', 'poly', 'MmmYYY']
     attrs[-1], attrs[-2] = attrs[-2], attrs[-1]
     # Join and get the new filename, e.g. => 'WDPA_poly_MmmYYY'
-    attrs.join('_')
+    [attrs, identifier].flatten.compact.join('_')
   end
 end

--- a/lib/modules/wdpa/s3.rb
+++ b/lib/modules/wdpa/s3.rb
@@ -28,8 +28,8 @@ class Wdpa::S3
   end
 
   def current_wdpa_identifier
-    # Assuming WDPA_MMMYYYY_Public.zip
-    current_wdpa.key.split('_').second
+    # Assuming WDPA_WDOECM_MMMYYYY_Public.zip
+    current_wdpa.key.split('_').third
   end
 
   private


### PR DESCRIPTION
## Description


* PAME download filename to follow YYYY-MMM version convention
* Standardise downloads filenames and features layers within GDB.
* For GDB exports, include source table within GDB file itself as in the original monthly release GDB

~~## TODO~~

~~* Single site downloads filenames should have a suffix to identify the area downloaded~~
~~* Look into splitting shapefiles into 3 parts only when strictly necessary (e.g. currently 3 shapefiles are generated even when downloading a single site)~~

[Codebase ticket](https://unep-wcmc.codebasehq.com/projects/protected-planet-support-and-maintenance/tickets/188)