### PR TITLE
fix/made sure returned filter options are unique

### DIFF
--- a/app/serializers/search/filters_serializer.rb
+++ b/app/serializers/search/filters_serializer.rb
@@ -82,7 +82,7 @@ class Search::FiltersSerializer < Search::BaseSerializer
 
   def objs_for(aggregation)
     records = sorted_records(@aggregations[aggregation], aggregation)
-    records.map { |obj| { id: obj[:label], title: obj[:label] } }
+    records.map { |obj| { id: obj[:label], title: obj[:label] } }.uniq
   end
 
   def sorted_records(records, agg_type)


### PR DESCRIPTION
**Ticket**

https://unep-wcmc.codebasehq.com/projects/protected-planet-support-and-maintenance/tickets/177

The filters for the search were showing duplicates, in particular the Designations filter options. I ensured that only unique options would be returned. 