### PR TITLE
Clear cache

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,8 +80,12 @@ group :test, :development do
   gem 'ejs'
   # gem 'minitest', '5.10.3' # Explicit minitest version fixes test reporting errors
   gem 'minitest', '~> 5.10', '!= 5.10.2'
-  gem 'byebug', '~> 9.0', '>= 9.0.5'
+  
 
+end
+
+group :test, :development, :staging do 
+  gem 'byebug', '~> 9.0', '>= 9.0.5'
 end
 
 

--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,7 @@ group :development do
   gem 'capistrano-git-with-submodules', '2.0.3'
   gem 'capistrano-service'
   gem 'awesome_print'
+
   # gem 'listen', '~> 3.1.5'
   # gem 'spring-watcher-listen', '~> 2.0.0'
   #

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -32,5 +32,5 @@ set :passenger_restart_with_touch, false
 namespace :deploy do
   after :publishing, 'service:pp_default:restart'
   after :publishing, 'service:pp_import:restart'
-  after :finishing, 'clear:cache'
+  after :published, 'deploy:clear_cache'
 end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -32,4 +32,5 @@ set :passenger_restart_with_touch, false
 namespace :deploy do
   after :publishing, 'service:pp_default:restart'
   after :publishing, 'service:pp_import:restart'
+  after :published, 'deploy:clear_cache'
 end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -32,5 +32,5 @@ set :passenger_restart_with_touch, false
 namespace :deploy do
   after :publishing, 'service:pp_default:restart'
   after :publishing, 'service:pp_import:restart'
-  after :finishing, 'cache:clear'
+  after :finishing, 'clear:cache'
 end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -32,5 +32,4 @@ set :passenger_restart_with_touch, false
 namespace :deploy do
   after :publishing, 'service:pp_default:restart'
   after :publishing, 'service:pp_import:restart'
-  after :published, 'deploy:clear_cache'
 end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -2,7 +2,7 @@
 lock '3.11.0'
 
 set :repo_url, 'git@github.com:unepwcmc/ProtectedPlanet.git'
-set :application, "ProtectedPlanet-copy"
+set :application, "ProtectedPlanet"
 
 set :deploy_user, 'wcmc'
 set :deploy_to, "/home/#{fetch(:deploy_user)}/#{fetch(:application)}"

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -12,7 +12,7 @@ set :branch, "master"
 
 
 namespace :deploy do
-  after :published, 'deploy:clear_cache RAILS_ENV=production'
+  after :published, 'deploy:clear_cache'
 end
 
 

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -11,6 +11,12 @@ set :branch, "master"
 
 
 
+namespace :deploy do
+  after :published, 'deploy:clear_cache'
+end
+
+
+
 # server-based syntax
 # ======================
 # Defines a single server with a list of roles and multiple properties.

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -10,13 +10,6 @@ set :app_port, "80"
 set :branch, "master"
 
 
-
-namespace :deploy do
-  after :published, 'deploy:clear_cache'
-end
-
-
-
 # server-based syntax
 # ======================
 # Defines a single server with a list of roles and multiple properties.

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -12,7 +12,7 @@ set :branch, "master"
 
 
 namespace :deploy do
-  after :published, 'deploy:clear_cache'
+  after :published, 'deploy:clear_cache RAILS_ENV=production'
 end
 
 

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -1,13 +1,16 @@
 set :stage, :staging
 set :branch, "clear_cache"
 
-server 'new-web-copy.pp-staging.linode.protectedplanet.net', user: 'wcmc', roles: %w{web app db}
+server 'new-web.pp-staging.linode.protectedplanet.net', user: 'wcmc', roles: %w{web app db}
 
-set :application, "protectedplanet-copy"
-set :server_name, "protectedplanet-copy"
+set :application, "protectedplanet"
+set :server_name, "protectedplanet"
 set :sudo_user, "wcmc"
 set :app_port, "80"
 
+namespace :deploy do
+  after :published, 'deploy:clear_cache RAILS_ENV=production'
+end
 
 
 # server-based syntax

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -1,5 +1,5 @@
 set :stage, :staging
-set :branch, "master"
+set :branch, "clear_cache"
 
 server 'new-web-copy.pp-staging.linode.protectedplanet.net', user: 'wcmc', roles: %w{web app db}
 

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -1,5 +1,5 @@
 set :stage, :staging
-set :branch, "clear_cache"
+set :branch, "develop"
 
 server 'new-web.pp-staging.linode.protectedplanet.net', user: 'wcmc', roles: %w{web app db}
 

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -8,11 +8,6 @@ set :server_name, "protectedplanet"
 set :sudo_user, "wcmc"
 set :app_port, "80"
 
-namespace :deploy do
-  after :published, 'deploy:clear_cache'
-end
-
-
 # server-based syntax
 # ======================
 # Defines a single server with a list of roles and multiple properties.

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -9,7 +9,7 @@ set :sudo_user, "wcmc"
 set :app_port, "80"
 
 namespace :deploy do
-  after :published, 'deploy:clear_cache RAILS_ENV=staging'
+  after :published, 'deploy:clear_cache'
 end
 
 

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -9,7 +9,7 @@ set :sudo_user, "wcmc"
 set :app_port, "80"
 
 namespace :deploy do
-  after :published, 'deploy:clear_cache RAILS_ENV=production'
+  after :published, 'deploy:clear_cache RAILS_ENV=staging'
 end
 
 

--- a/lib/capistrano/tasks/cache.rake
+++ b/lib/capistrano/tasks/cache.rake
@@ -1,9 +1,10 @@
-namespace :cache do
-  task :clear do
-    on roles(:all) do
-      within release_path do
-        with rails_env: fetch(:rails_env) do
-          execute :rails, 'cache:clear'
+namespace :clear do
+  desc 'clear rails cache'
+  task :cache do
+    on roles(:app) do
+      within "#{current_path}" do
+        with rails_env: "#{fetch(:stage)}" do
+          execute :rake, "cache:clear"
         end
       end
     end

--- a/lib/capistrano/tasks/cache.rake
+++ b/lib/capistrano/tasks/cache.rake
@@ -1,12 +1,11 @@
-namespace :clear do
-  desc 'clear rails cache'
-  task :cache do
-    on roles(:app) do
-      within "#{current_path}" do
-        with rails_env: "#{fetch(:stage)}" do
-          execute :rake, "cache:clear"
+namespace :deploy do
+    task :clear_cache do
+        on roles(:app) do |host|
+            with rails_env: fetch(:rails_env) do
+                within current_path do
+                    execute :rake, "cache:clear"
+                end
+            end
         end
-      end
     end
-  end
 end

--- a/lib/tasks/cache.rake
+++ b/lib/tasks/cache.rake
@@ -1,11 +1,12 @@
 namespace :cache do
   desc "Clear the Rails cache (everything except downloads which is handled by Redis)"
-  task :clear do
+  task clear: :environment do
+    abort('Aborting: Rails cache is nil') if Rails.cache.nil?
+
     logger = Logger.new(STDOUT)
 
     logger.info "Clearing cache..."
 
-    abort('Aborting: Rails cache is nil') if Rails.cache.nil?
     Rails.cache.clear
 
     logger.info "Done."

--- a/lib/tasks/cache.rake
+++ b/lib/tasks/cache.rake
@@ -1,6 +1,6 @@
 namespace :cache do
   desc "Clear the Rails cache (everything except downloads which is handled by Redis)"
-  task clear: do
+  task :clear do
     logger = Logger.new(STDOUT)
 
     logger.info "Clearing cache..."

--- a/lib/tasks/cache.rake
+++ b/lib/tasks/cache.rake
@@ -1,11 +1,11 @@
 namespace :cache do
   desc "Clear the Rails cache (everything except downloads which is handled by Redis)"
-  task :clear do
+  task clear: do
     logger = Logger.new(STDOUT)
 
     logger.info "Clearing cache..."
 
-    abort('Rails cache is nil') if Rails.cache.nil?
+    abort('Aborting: Rails cache is nil') if Rails.cache.nil?
     Rails.cache.clear
 
     logger.info "Done."


### PR DESCRIPTION
This is a second, more formal attempt to allow the rake task to clear the cache to run during deployment.

A new Capistrano task has been created in `lib/capistrano/tasks` to allow the Rake task it calls access to the current environment, either staging or production. This should no longer therefore error during deployment. 

Also, the byebug gem has now been added to staging as well for better debugging. 

I'd recommend first to try to deploy to staging before merging in. 