### PR TITLE
Fix/ticket 193

### DIFF
--- a/app/controllers/country_controller.rb
+++ b/app/controllers/country_controller.rb
@@ -70,13 +70,12 @@ class CountryController < ApplicationController
   end
 
   def build_hash(tab)
-    oecm = tab == :wdpa_oecm
     hash = {}
 
     # What this does is call the corresponding method in tab presenter to build
     # the value for each key, populating the hash
     hash[tab] = TABS_KEYS.map do |key|
-      { "#{key}": @tab_presenter.send("#{key}", oecms_tab: oecm) }
+      { "#{key}": @tab_presenter.send("#{key}", oecms_tab: tab == :wdpa_oecm) }
     end.reduce(&:merge)
 
     hash
@@ -99,7 +98,6 @@ class CountryController < ApplicationController
 
     @country or raise_404
 
-    @pame_statistics = @country.pame_statistic
     @country_presenter = CountryPresenter.new(@country)
     @tab_presenter = TabPresenter.new(@country)
   end

--- a/app/presenters/country_presenter.rb
+++ b/app/presenters/country_presenter.rb
@@ -65,8 +65,8 @@ class CountryPresenter
   def build_stats(type)
     {
       national_report_version: statistic.nr_version,
-      pame_km2: number_with_delimiter(statistic.pame_statistic.send("pame_pa_#{type}_area").round(0)),
-      pame_percentage: statistic.pame_statistic.send("pame_percentage_pa_#{type}_cover").round(2),
+      pame_km2: number_with_delimiter(statistic&.pame_statistic&.send("pame_pa_#{type}_area")&.round(0)),
+      pame_percentage: statistic&.pame_statistic&.send("pame_percentage_pa_#{type}_cover")&.round(2),
       protected_km2: number_with_delimiter(statistic.send("pa_#{type}_area").round(0)),
       protected_national_report: statistic.send("percentage_nr_#{type}_cover"),
       protected_percentage: statistic.send("percentage_pa_#{type}_cover").round(2),


### PR DESCRIPTION
**TIcket**

https://unep-wcmc.codebasehq.com/projects/protected-planet-support-and-maintenance/tickets/193

I added safe navigation operators (the `&`) to the Country presenter's `build_stats` method when it fetches the PAME stats from the Statistic presenter as PAME statistics aren't available for every single national entity. This is a quick and dirty solution as there's other things that could be improved upon, but we want to get the pages for San Marino and the other three 'countries' working again quickly (Nauru, Vatican City and Macau).