### PR TITLE
refactor: temporarily hide circular stats div on wdpa, oecm and homepage

### DIFF
--- a/app/assets/stylesheets/components/_hero.scss
+++ b/app/assets/stylesheets/components/_hero.scss
@@ -50,6 +50,9 @@
     @include flex;
     @include flex-column;
     @include responsive(margin, rem-calc(22) auto 0 auto, 0 0 0 auto, 0 0 0 0);
+
+    // Temporarily hidden
+    display: none;
   }
 
     .hero__icon { 


### PR DESCRIPTION
**Ticket**

https://unep-wcmc.codebasehq.com/projects/protected-planet-support-and-maintenance/tickets/198 

Added `display: none` to the `hero-stat-bubble` mixin along with a comment to indicate that it's temporarily hidden. 