### PR TITLE
fix: use the correct legend key for high seas bar chart

### DIFF
--- a/app/helpers/marine_helper.rb
+++ b/app/helpers/marine_helper.rb
@@ -20,7 +20,7 @@ module MarineHelper
       },
       {
         theme: 'theme--blue',
-        title: t('thematic_area.marine.ocean.legend_text_2'),
+        title: t('thematic_area.marine.ocean.legend_text_3'),
       }
     ]
   end


### PR DESCRIPTION
**Ticket**

https://unep-wcmc.codebasehq.com/projects/protected-planet-support-and-maintenance/tickets/205

Used the correct legend key (from the associated YML) for '% Ocean that is High seas' in the High Seas bar chart under MPA page