### PR TITLE
Fix the API

### DIFF
--- a/lib/data/seeds/jurisdictions.csv
+++ b/lib/data/seeds/jurisdictions.csv
@@ -4,3 +4,4 @@ International
 Regional
 ABNJ
 Not Reported
+Not Applicable


### PR DESCRIPTION
**Ticket**

https://unep-wcmc.codebasehq.com/projects/protected-planet-support-and-maintenance/tickets/122

- Include 'Not Applicable' in `jurisdictions.csv` in the `seeds` folder. This fixes the reported issue of PAs being returned with `nil` jurisdiction. On production I'll manually create the new Jurisdiction before running the import again. 

Other changes in the ticket will be made in a separate PR

**Notes**

Seeding a new db will automatically create the missing jurisdiction. 

In an existing db, can only really be tested by creating a new Jurisdiction instance with 'Not Applicable' as the name and then importing the monthly release into that DB. 