### PR TITLE
Country#show: Disable download if no wdpas

### DIFF
--- a/app/assets/stylesheets/components/_download.scss
+++ b/app/assets/stylesheets/components/_download.scss
@@ -50,5 +50,7 @@
     @include breakpoint-down($small) { 
       width: rem-calc(38); height: rem-calc(38);
     }
+
+    &.disabled { @include button-disabled; }
   }
 }

--- a/app/javascript/components/download/Download.vue
+++ b/app/javascript/components/download/Download.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <button
-      class="download__trigger"
+      :class="['download__trigger', { 'disabled': downloadDisabled }]"
       @click="toggleDownloadPane"
     >
       <span class="download__trigger-text">{{ buttonText }}</span>
@@ -41,7 +41,12 @@ export default {
     textCommercial: {
       required: true,
       type: Object //See download_text in downloads_helper.rb
-    }
+    },
+    downloadDisabled: {
+      default: false,
+      required: false,
+      type: Boolean
+    },
   },
 
   data () {
@@ -93,6 +98,7 @@ export default {
     },
 
     toggleDownloadPane () {
+      if (this.downloadDisabled) return;
       this.showPopup = !this.showPopup
     }
   }

--- a/app/views/country/show.html.erb
+++ b/app/views/country/show.html.erb
@@ -1,6 +1,6 @@
 <%= render partial: "./partials/bars/topbar-secondary", locals: { 
   download_options: @download_options,
-  download_disabled: @total_wdpa.zero?
+  download_disabled: @total_wdpa == 0
 } %>
 
 <div class="page--country bg--grey-xlight spacer-small--top">

--- a/app/views/country/show.html.erb
+++ b/app/views/country/show.html.erb
@@ -1,5 +1,6 @@
 <%= render partial: "./partials/bars/topbar-secondary", locals: { 
-  download_options: @download_options 
+  download_options: @download_options,
+  download_disabled: @total_wdpa.zero?
 } %>
 
 <div class="page--country bg--grey-xlight spacer-small--top">

--- a/app/views/partials/bars/_topbar-secondary.html.erb
+++ b/app/views/partials/bars/_topbar-secondary.html.erb
@@ -8,7 +8,8 @@
 
       <%= render partial: "partials/download/download", locals: { 
         classes: 'download--small', 
-        options: download_options
+        options: download_options,
+        download_disabled: local_assigns.has_key?(:download_disabled) ? download_disabled : false
       } %>
     </div>
   </sticky-bar>

--- a/app/views/partials/download/_download.html.erb
+++ b/app/views/partials/download/_download.html.erb
@@ -5,6 +5,10 @@
     class="<%= classes %>"
   <% end %>
 
+  <% if local_assigns.has_key? :download_disabled %>
+  :download-disabled="<%= download_disabled %>"
+  <% end %>
+  
   gaId="download"
   :options="<%= options %>"
   :text-commercial="<%= download_text[:commercial].to_json %>"


### PR DESCRIPTION
These changes address [Ticket #211](https://unep-wcmc.codebasehq.com/projects/protected-planet-support-and-maintenance/tickets/211).

The aim of these changes was to disable the "Download" button in the topbar of the Country#show view if the country has no WDPAs, e.g. for the Vatican City (see screenshot).

@stacytalbot suggested that the disabled button have similar styles to the disabled "Filter" button on the country search view (see screenshot).

<img width="1178" alt="image" src="https://user-images.githubusercontent.com/56026099/118978764-9ce9ab80-b96f-11eb-8dd2-75059b697761.png">

<img width="140" alt="image" src="https://user-images.githubusercontent.com/56026099/118979116-0a95d780-b970-11eb-95a0-0129dfafe856.png">