### PR TITLE
Add cookie banner using cookieconsent package

### DIFF
--- a/app/javascript/vue.js
+++ b/app/javascript/vue.js
@@ -9,6 +9,10 @@ import VueAnalytics from 'vue-analytics'
 import Vue2TouchEvents from 'vue2-touch-events'
 import VueLazyload from 'vue-lazyload'
 
+// cookieconsent
+import 'cookieconsent';
+import 'cookieconsent/build/cookieconsent.min.css';
+
 // store
 import store from './store/store.js'
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,6 +5,9 @@
   </head>
 
   <body>
+    
+    <%= render "layouts/partials/cookieconsent" %>
+
     <div id="v-app" class="<%= if @for_pdf then 'pdf' end %>">
       <%= render "layouts/partials/topbar" %>
         

--- a/app/views/layouts/partials/_cookieconsent.html.erb
+++ b/app/views/layouts/partials/_cookieconsent.html.erb
@@ -1,20 +1,22 @@
 <script>
-   cookieconsent.initialise({
-        palette: {
-            popup: {background: "#fff"},
-            button: {
-                background: "#71A32B",
-                text: '#fff'
-            },
-        },
-        revokable: true,
-        onStatusChange: function(status) {
-        console.log(this.hasConsented() ?
-        'enable cookies' : 'disable cookies');
-        },
-        law: {
-        regionalLaw: false,
-        },
-        location: true,
-   });
+  cookieconsent.initialise({
+    palette: {
+      popup: {
+        background: "#404040",
+        text: '#fff'
+      },
+      button: {
+        background: "#71A32B",
+        text: '#fff'
+      },
+    },
+    revokable: true,
+    onStatusChange: function(status) {
+      console.log(this.hasConsented() ? 'enable cookies' : 'disable cookies');
+    },
+    law: {
+      regionalLaw: false,
+    },
+    location: true,
+  });
 </script>

--- a/app/views/layouts/partials/_cookieconsent.html.erb
+++ b/app/views/layouts/partials/_cookieconsent.html.erb
@@ -1,0 +1,20 @@
+<script>
+   cookieconsent.initialise({
+        palette: {
+            popup: {background: "#fff"},
+            button: {
+                background: "#71A32B",
+                text: '#fff'
+            },
+        },
+        revokable: true,
+        onStatusChange: function(status) {
+        console.log(this.hasConsented() ?
+        'enable cookies' : 'disable cookies');
+        },
+        law: {
+        regionalLaw: false,
+        },
+        location: true,
+   });
+</script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -2916,6 +2916,11 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
+    "cookieconsent": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookieconsent/-/cookieconsent-3.1.1.tgz",
+      "integrity": "sha512-v8JWLJcI7Zs9NWrs8hiVldVtm3EBF70TJI231vxn6YToBGj0c9dvdnYwltydkAnrbBMOM/qX1xLFrnTfm5wTag=="
+    },
     "copy-concurrently": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
@@ -7465,8 +7470,7 @@
     "picomatch": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
-      "optional": true
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
     },
     "pify": {
       "version": "4.0.1",
@@ -10928,6 +10932,11 @@
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
       }
+    },
+    "url-search-params-polyfill": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/url-search-params-polyfill/-/url-search-params-polyfill-8.1.1.tgz",
+      "integrity": "sha512-KmkCs6SjE6t4ihrfW9JelAPQIIIFbJweaaSLTh/4AO+c58JlDcb+GbdPt8yr5lRcFg4rPswRFRRhBGpWwh0K/Q=="
     },
     "use": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@rails/webpacker": "^4.0.2",
     "axios": "^0.19.0",
     "babel-polyfill": "^6.26.0",
+    "cookieconsent": "^3.1.1",
     "d3": "^5.9.2",
     "dotenv-webpack": "^1.7.0",
     "es6-object-assign": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2231,6 +2231,11 @@ cookie@0.4.0:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
   integrity sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==
 
+cookieconsent@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/cookieconsent/-/cookieconsent-3.1.1.tgz#f90bfadcaeef7d2bdcdd8278257f7264cb5d6819"
+  integrity sha512-v8JWLJcI7Zs9NWrs8hiVldVtm3EBF70TJI231vxn6YToBGj0c9dvdnYwltydkAnrbBMOM/qX1xLFrnTfm5wTag==
+
 copy-concurrently@^1.0.0:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/copy-concurrently/-/copy-concurrently-1.0.5.tgz#92297398cae34937fcafd6ec8139c18051f0b5e0"


### PR DESCRIPTION
**This Pull Request addresses Protected Planet - Support & Maintenance [Ticket 163](https://unep-wcmc.codebasehq.com/projects/protected-planet-support-and-maintenance/tickets/163), "Cookie Compliance Banner".**

I tried to use the `cookieconsent` gem at first, but came across some problems where Sprockets wasn't including it, so I went via the npm/webpacker route instead.

- `cookieconsent` package added via npm and imported in `vue.js`
- `_cookieconsent.html.erb` partial created to store the necessary script tag where the cookieconsent banner is initialised.
- That partial is then rendered at the top of the body in `application.html.erb`.

Note: There are lots of config options to customise the appearance and behaviour of the banner. I've left it quite simple for now and given the button a colour to match the colour scheme of the page.

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/56026099/119686438-3d434280-be3e-11eb-93af-326666f19b93.png">
