### PR TITLE
Ticket 218/filepath too long

### DIFF
--- a/lib/modules/download/utils.rb
+++ b/lib/modules/download/utils.rb
@@ -80,6 +80,7 @@ module Download
     end
 
     def self.search_token term, filters
+      return '' if (term.empty? && filters.empty?)
       Digest::SHA256.hexdigest(term.to_s + filters_dump(filters))
     end
 

--- a/lib/modules/download/utils.rb
+++ b/lib/modules/download/utils.rb
@@ -80,7 +80,7 @@ module Download
     end
 
     def self.search_token term, filters
-      return '' if (term.empty? && filters.empty?)
+      return 'all' if (term.empty? && filters.empty?)
       Digest::SHA256.hexdigest(term.to_s + filters_dump(filters))
     end
 


### PR DESCRIPTION
Codebase ticket  https://unep-wcmc.codebasehq.com/projects/protected-planet-support-and-maintenance/tickets/218

When the full dataset gets downloaded from the search page https://pp.new-web.pp-staging.linode.protectedplanet.net/en/search-areas?geo_type=country without applying any filters or search term, an identifier (SHA256 hash) gets unnecessarily added as a suffix to the filename.
This is a hotfix to prevent this