### PR TITLE
Added new attributes to WDPA api response

### DIFF
--- a/app/models/protected_area.rb
+++ b/app/models/protected_area.rb
@@ -147,7 +147,7 @@ class ProtectedArea < ApplicationRecord
 
   def as_api_feeder
     attributes = self.as_json(
-      only: [:wdpa_id, :name, :original_name, :marine, :legal_status_updated_at, :reported_area]
+      only: [:wdpa_id, :name, :original_name, :marine, :legal_status_updated_at, :reported_area, :international_criteria, :management_plan]
     )
 
     relations = {
@@ -158,7 +158,8 @@ class ProtectedArea < ApplicationRecord
       legal_status: {'name' => legal_status.try(:name)},
       governance: {'name' => governance.try(:name)},
       networks_no: networks.count,
-      designations_no: networks.detect(&:designation).try(:protected_areas).try(:count) || 0
+      designations_no: networks.detect(&:designation).try(:protected_areas).try(:count) || 0,
+      management_authority: {'name' => management_authority.try(:name)}
     }.as_json
 
     relations.merge attributes

--- a/app/models/protected_area.rb
+++ b/app/models/protected_area.rb
@@ -147,7 +147,12 @@ class ProtectedArea < ApplicationRecord
 
   def as_api_feeder
     attributes = self.as_json(
-      only: [:wdpa_id, :name, :original_name, :marine, :legal_status_updated_at, :reported_area, :international_criteria, :management_plan]
+      only: [
+        :wdpa_id, :name, :original_name, :owner_type,
+        :international_criteria, :is_green_list,
+        :management_plan, :legal_status_updated_at,
+        :reported_area, :marine, :reported_marine_area
+      ]
     )
 
     relations = {
@@ -159,7 +164,9 @@ class ProtectedArea < ApplicationRecord
       governance: {'name' => governance.try(:name)},
       networks_no: networks.count,
       designations_no: networks.detect(&:designation).try(:protected_areas).try(:count) || 0,
-      management_authority: {'name' => management_authority.try(:name)}
+      management_authority: {'name' => management_authority.try(:name)},
+      pame_evaluations: pame_evaluations.map {|pe| {'name' => pe.try(:name), 'methodology' => pe.try(:methodology), 'year' => pe.try(:year), 'url' => pe.try(:url), 'assessment_is_public' => pe.try(:assessment_is_public) }},
+      no_take_status: {'name' => no_take_status.try(:name), 'area' => no_take_status.try(:area) }
     }.as_json
 
     relations.merge attributes


### PR DESCRIPTION
Added :international_criteria, :management_plan, and :management_authority to the Protected Planet API. 

Example response:

```
{
    "sub_locations": [],
    "countries": [
        {
            "name": "Liberia",
            "iso_3": "LBR",
            "region": {
                "name": "Africa"
            }
        }
    ],
    "iucn_category": {
        "name": "Not Reported"
    },
    "designation": {
        "name": "National Forest Park",
        "jurisdiction": {
            "name": "National"
        }
    },
    "legal_status": {
        "name": "Proposed"
    },
    "governance": {
        "name": "Federal or national ministry or agency"
    },
    "networks_no": 0,
    "designations_no": 0,
    "management_authority": {
        "name": "Department of Forest Conservation, Forestry Development Authority"
    },
    "wdpa_id": 9170,
    "name": "Grebo National Forest Park",
    "original_name": "Grebo National Forest Park",
    "marine": false,
    "reported_area": "971.35738",
    "legal_status_updated_at": "2003-01-01T00:00:00.000Z",
    "management_plan": "Not Reported",
    "international_criteria": "Not Applicable"
}
```