### PR TITLE
feat: change locale to include OECMs in search card descriptions

### DIFF
--- a/config/locales/search/en.yml
+++ b/config/locales/search/en.yml
@@ -48,7 +48,7 @@ en:
       site: Individual Areas
     map: Map View
     no-results: No results. Please search again.
-    protected-areas: Protected Areas
+    protected-areas: protected areas and other effective area-based conservation measures
     results: results
     search-areas-title: Explore protected areas and OECMs
     


### PR DESCRIPTION
https://unep-wcmc.codebasehq.com/projects/protected-planet-support-and-maintenance/tickets/248

Wording change on cards on search page.

Testing
go to ```http://localhost:3000/en/search-areas?geo_type=country``` and look at the cards