### PR TITLE
fix: stop trying to load the_geom into memory, because some are huge …

### DIFF
--- a/app/models/protected_area.rb
+++ b/app/models/protected_area.rb
@@ -254,7 +254,10 @@ class ProtectedArea < ApplicationRecord
   private
 
   def is_point?
-    the_geom.geometry_type.type_name.match('Point').present?
+    @is_point ||= begin
+      extent = bounds
+      extent[0][0] == extent[1][0] && extent[0][1] == extent[1][1]
+    end
   end
 
   def bounding_box_query


### PR DESCRIPTION
…and this stopped pages loading

https://unep-wcmc.codebasehq.com/projects/protected-planet-support-and-maintenance/tickets/262
https://unep-wcmc.codebasehq.com/projects/protected-planet-support-and-maintenance/tickets/253

is_point? was loading the_geom into memory, which was failing because some have thousands and thousands of points. this uses the extent of the bounding box instead.

Testing:
on develop try to access any of these pages at ```localhost:3000/:wdpa_id```:
```
 wdpa_id  | octet_length 
-----------+--------------
 555651780 |    161123160
 555643543 |    126382439
 555705169 |    108191918
 555643544 |     90828975
 555592567 |     53603603
 555656200 |     47660594
     10547 |     46233177
   1111190 |     33158115
 555697618 |     31715621
 555655904 |     30289009
      2898 |     29591422
 555534657 |     27599600
 555638687 |     25516688
 555559195 |     23288218
     20603 |     22088575
 555691675 |     21384299
 555559204 |     21384270
       972 |     21108794
 555621403 |     19480793
 555534356 |     19423361
 555638692 |     18582412
 555637441 |     18049233
 555671921 |     17581173
 555637720 |     15821876
 555638689 |     15710290
 555621413 |     14556890
```
it should fail
on this branch try to access them and it should work
```localhost:3000/13979``` is a point PA, and this should load correctly

polygons in the map still load slowly, and there's another ticket for that 
