### PR TITLE
feat: added maxZoom: 10 to mapbox defaults, and overide in the protec…

### DIFF
--- a/app/controllers/protected_areas_controller.rb
+++ b/app/controllers/protected_areas_controller.rb
@@ -43,7 +43,8 @@ class ProtectedAreasController < ApplicationController
 
     @map_options = {
       map: {
-        boundsUrl: @protected_area.extent_url
+        boundsUrl: @protected_area.extent_url,
+        maxZoom: 0
       }
     }
 

--- a/app/javascript/components/map/default-options.js
+++ b/app/javascript/components/map/default-options.js
@@ -17,6 +17,7 @@ export const MAP_OPTIONS_DEFAULT = {
   attributionControl: false,
   preserveDrawingBuffer: true, // needed for PDF rendering
   zoom: 1.3,
+  maxZoom: 10 // Maximum zoom where tiles are cached for the web-map service
   //bounds: [[-180, -90], [180, 90]],
   //boundingISO: ISO3,
   //boundingRegion; Name e.g. Europe,


### PR DESCRIPTION
…ted area controller

https://unep-wcmc.codebasehq.com/projects/protected-planet-support-and-maintenance/tickets/230

Maps that show the cached webmap service tiles have an issue where the Protected Areas disappear beyond a zoom level (10), because they aren't cached. this is already a pretty close zoom, so for now i've limited the default zoom to 10. this can be overridden in the map_options object, and i've done so here for the protected area show page, because that loads a single polygon retrieved from a different source, so can be zoomed in to any level

Testing:
go to the different map pages (country, site, homepage, examples listed in the codebase ticket), and zoom in as far as possible.  PAs should not disappear.