### PR TITLE
Use correct bucket for file downloads

### DIFF
--- a/lib/modules/wdpa/release.rb
+++ b/lib/modules/wdpa/release.rb
@@ -14,7 +14,7 @@ class Wdpa::Release
   end
 
   def download
-    Wdpa::S3.download_current_wdpa_to zip_path
+    Wdpa::S3.download_latest_wdpa_to zip_path
     system("unzip -j '#{zip_path}' '\*.gdb/\*' -d '#{gdb_path}'")
 
     import_tables.each do |original_table, std_table|

--- a/lib/modules/wdpa/s3.rb
+++ b/lib/modules/wdpa/s3.rb
@@ -7,8 +7,8 @@ class Wdpa::S3
     })
   end
 
-  def self.download_current_wdpa_to filename
-    self.new.tap{ |s3| s3.download_current_wdpa_to filename }
+  def self.download_latest_wdpa_to filename
+    self.new.tap{ |s3| s3.download_latest_wdpa_to filename }
   end
 
   def self.new_wdpa? since
@@ -19,12 +19,12 @@ class Wdpa::S3
     new.current_wdpa_identifier
   end
 
-  def download_current_wdpa_to filename
-    current_wdpa.get(response_target: filename, response_content_encoding: 'ASCII_8BIT')
+  def download_latest_wdpa_to filename
+    latest_wdpa.get(response_target: filename, response_content_encoding: 'ASCII_8BIT')
   end
 
   def new_wdpa? since
-    current_wdpa.last_modified > since
+    latest_wdpa.last_modified > since
   end
 
   def current_wdpa_identifier
@@ -34,7 +34,7 @@ class Wdpa::S3
 
   private
 
-  def current_wdpa
+  def latest_wdpa
     latest = available_wdpa_databases.max_by do |object|
       filename = object.key # e.g. "WDPA_WDOECM_Sep2020_Public.gdb.zip"
 
@@ -44,6 +44,15 @@ class Wdpa::S3
       Date.parse('1900-01-01')
     end
     latest.object
+  end
+
+  def current_wdpa
+    wdpa_from_constants = available_wdpa_databases.find do |object|
+      object.key.include?("#{WDPA_UPDATE_MONTH.first(3)}#{WDPA_UPDATE_YEAR}")
+    end
+    wdpa_from_constants ? wdpa_from_constants.object : latest_wdpa
+  rescue
+    latest_wdpa
   end
 
   def available_wdpa_databases

--- a/test/unit/wdpa/release_test.rb
+++ b/test/unit/wdpa/release_test.rb
@@ -8,7 +8,7 @@ class TestWdpaRelease < ActiveSupport::TestCase
     gdb_path = "gdb_path"
     Wdpa::Release.any_instance.expects(:gdb_path).returns(gdb_path).at_least_once
 
-    Wdpa::S3.expects(:download_current_wdpa_to).with(zip_path)
+    Wdpa::S3.expects(:download_latest_wdpa_to).with(zip_path)
 
     Wdpa::Release.any_instance.
       expects(:system).

--- a/test/unit/wdpa/s3_test.rb
+++ b/test/unit/wdpa/s3_test.rb
@@ -22,7 +22,7 @@ class TestWdpaS3Downloader < ActiveSupport::TestCase
     Wdpa::S3.new()
   end
 
-  test '.download_current_wdpa_to handles encoding correctly' do
+  test '.download_latest_wdpa_to handles encoding correctly' do
     filename = File.join(Rails.root, 'tmp', 'hey_this_is_a_filename.zip')
     file_contents = "\x9B".force_encoding(Encoding::ASCII_8BIT)
 
@@ -34,10 +34,10 @@ class TestWdpaS3Downloader < ActiveSupport::TestCase
     @bucket_mock.stubs(:objects).returns([latest_file_mock])
     Aws::S3::Resource.stubs(:new).returns(@s3_mock)
 
-    Wdpa::S3.download_current_wdpa_to filename
+    Wdpa::S3.download_latest_wdpa_to filename
   end
 
-  test '.download_current_wdpa_to retrieves the latest WDPA from S3, and saves it to the
+  test '.download_latest_wdpa_to retrieves the latest WDPA from S3, and saves it to the
    given filename' do
     filename = 'hey_this_is_a_filename.zip'
     latest_file_mock = mock()
@@ -56,7 +56,7 @@ class TestWdpaS3Downloader < ActiveSupport::TestCase
 
     Aws::S3::Resource.stubs(:new).returns(@s3_mock)
 
-    Wdpa::S3.download_current_wdpa_to filename
+    Wdpa::S3.download_latest_wdpa_to filename
   end
 
   test '.new_wdpa? compares the current wdpa last modified time with the given


### PR DESCRIPTION
https://unep-wcmc.codebasehq.com/projects/protected-planet-support-and-maintenance/tickets/272

Second attempt at fixing this bug.

File downloads always point at the latest version of the database in the s3 buckets. Last attempt to fix it broke because the monthly import looks in the same place as the file downloads for the file, so it was only finding the current release's file using the constants in the constants.rb, not the newer one.

This points file downloads to the current release files and the monthly import to the current release. 

Testing:
I found it easiest to update the secrets file so all development credentials point to the production buckets, then:
download a csv and shapefile for a country (jordan and Tanzania had changes recently so is a good choice)- should be the latest bucket (currently Jun 2022).
update the constants to an earlier date (for Jordan and Tazania the changes appeared in Mar 2022 release, so before that) 
restart sidekiq and the rails server
redownload the shp file and csv for the same country
compare the files, later files should be bigger

I haven't tested the full import yet