### PR TITLE
feat: hid PA growth chart from country and region pages

### DIFF
--- a/app/javascript/components/pages/RegionCountryPages.vue
+++ b/app/javascript/components/pages/RegionCountryPages.vue
@@ -86,14 +86,18 @@
       }"
     />
 
-    <stats-growth
-      v-if="hasGrowth"
-      v-bind="{
-        chart: activeDatabase.growth.chart,
-        smallprint: activeDatabase.growth.smallprint,
-        title: activeDatabase.growth.title,
-      }"
-    />
+    <!--
+      Growth chart hidden because calculation is incorrect
+      https://unep-wcmc.codebasehq.com/projects/protected-planet-support-and-maintenance/tickets/265
+      <stats-growth
+        v-if="hasGrowth"
+        v-bind="{
+          chart: activeDatabase.growth.chart,
+          smallprint: activeDatabase.growth.smallprint,
+          title: activeDatabase.growth.title,
+        }"
+      />
+    -->
 
     <slot name="related_countries" />
 


### PR DESCRIPTION
https://unep-wcmc.codebasehq.com/projects/protected-planet-support-and-maintenance/tickets/265

Hides the growth chart on country and region show pages, because they aren't calculated correctly or showing area. 

Testing:

go to a country page, e.g., http://localhost:3000/country/JOR
see no growth chart