### PR TITLE
feat: hide mpa button download and left comment

### DIFF
--- a/app/controllers/marine_controller.rb
+++ b/app/controllers/marine_controller.rb
@@ -20,7 +20,8 @@ class MarineController < ApplicationController
     @marineSitesTotal = number_with_delimiter(ProtectedArea.marine_areas.count())
     @marineViewAllUrl = search_areas_path(filters: {is_type: ['marine']}) 
 
-    @download_options = helpers.download_options(['csv', 'shp', 'gdb', 'mpa_map'], 'general', 'marine')
+    # Removed mpa_map from ['csv', 'shp', 'gdb', 'map_map'] in feat/hide-mpa-download-button
+    @download_options = helpers.download_options(['csv', 'shp', 'gdb'], 'general', 'marine')
 
     @regionCoverage = Region.without_global.map do |region|
       RegionPresenter.new(region).marine_coverage


### PR DESCRIPTION
https://unep-wcmc.codebasehq.com/projects/protected-planet-support-and-maintenance/tickets/256

Removed the MP button download.

Testing:
'MPA Map' should no longer appear in the download list on https://www.protectedplanet.net/en/thematic-areas/marine-protected-areas