### PR TITLE
fix: give correct link for regions in filter results

### DIFF
--- a/app/serializers/search/base_serializer.rb
+++ b/app/serializers/search/base_serializer.rb
@@ -39,6 +39,8 @@ class Search::BaseSerializer
       protected_area_path(obj.wdpa_id)
     elsif obj.is_a?(Country)
       country_path(iso: obj.iso_3)
+    elsif obj.is_a?(Region)
+      region_path(iso: obj.iso)
     else
       '#'
     end


### PR DESCRIPTION
https://unep-wcmc.codebasehq.com/projects/protected-planet-support-and-maintenance/tickets/273

Regions returned by filter results did not link correctly to the region page

Testing:
search for a region (north america, europe, africa etc)
link should take you to that page

NOTE: bounding box isn't selected properly. think this should be fixed in another ticket where will try to pass up bounding boxed using our own database, because the bounding boxes from the api we use has issues (e.g. dateline bounding boxes fail)