### PR TITLE
fix: country zoom url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Stopped trying to load geom into memory and use extent to determine whether PA is point or polygon
 - Fixed region links on search results
 - Minor text changes
-- 
+
 ### 4.8.13
 - Removed MPA download option
 - Changed Mapbox basemap to most recent version

--- a/app/helpers/map_helper.rb
+++ b/app/helpers/map_helper.rb
@@ -104,7 +104,7 @@ module MapHelper
 
   def country_extent_url (iso3)
     {
-      url: "https://data-gis.unep-wcmc.org/server/rest/services/GADM_EEZ_Layer/FeatureServer/0/query?where=iso_ter+%3D+#{iso3}&returnGeometry=false&returnExtentOnly=true&outSR=4326&f=pjson",
+      url: "https://data-gis.unep-wcmc.org/server/rest/services/GADM_EEZ_Layer/FeatureServer/0/query?where=iso_ter+%3D+%27#{iso3}%27&returnGeometry=false&returnExtentOnly=true&outSR=4326&f=pjson",
       padding: 5
     }
   end


### PR DESCRIPTION
fixes broken country url

got to home page, enter country into search on map
should zoom to country
same for region, e.g. Latin America & Caribbean