### PR TITLE
fix: update designations presenter and country and region classes to …

### DIFF
--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -98,15 +98,16 @@ class Country < ApplicationRecord
     convert_into_hash(sources.uniq)
   end
 
-  def protected_areas_per_designation(jurisdiction=nil, exclude_oecms: false)
+  def protected_areas_per_designation(jurisdictions=[], exclude_oecms: false)
     ActiveRecord::Base.connection.execute("""
-      SELECT designations.id AS designation_id, designations.name AS designation_name, pas_per_designations.count
+      SELECT designations.name AS designation_name, SUM(pas_per_designations.count) as count
       FROM designations
       INNER JOIN (
         #{protected_areas_inner_join(:designation_id, exclude_oecms)}
       ) AS pas_per_designations
         ON pas_per_designations.designation_id = designations.id
-      #{"WHERE designations.jurisdiction_id = #{jurisdiction.id}" if jurisdiction}
+      #{"WHERE designations.jurisdiction_id IN (#{jurisdictions.pluck(:id).join(',')})" if jurisdictions.any?}
+      GROUP BY designations.name
     """)
   end
 


### PR DESCRIPTION
…return 'Not Applicable' designations along with 'National' designations

https://unep-wcmc.codebasehq.com/projects/protected-planet-support-and-maintenance/tickets/241

before: PAs designated as 'Not Applicable' were not included in the Designations tables in the country and region show pages

after: they are included in the 'National' designations.

changes: 
- updated the ```protected_areas_per_designation``` method in country and region to take an array of designations instead of one
- updated the SQL method in ```protected_areas_per_designation``` to use IN instead of =, and to group by designation name (because there are separate records for e.g. Marine Protected Area for each designation type, i.e. 'Not Applicable', 'National' etc 
- updated the presenter to pass a list of jurisdictions to ```protected_areas_per_designation```, adding 'Not Applicable' when jurisdiction == 'National'
- used the response from ```protected_areas_per_designation``` to generate count and % statistics, rather than having to hack the existing methods

Testing:
- go to pages where countries have some 'Not Applicable' PAs, e.g. Samoa http://localhost:3000/country/WSM
- On this branch the total at the top of the page should match the sum of the different jurisdictions
![image](https://user-images.githubusercontent.com/15033504/182150197-9a62e19e-89fc-4997-ac6d-0d958c309575.png)
![image](https://user-images.githubusercontent.com/15033504/182150137-6729bad0-293b-49d5-bab7-e7acc19f8950.png)

- on develop the above should not match
- on this branch Marine protected area count should be higher than on develop
- should work the same for regions