### PR TITLE
fix: replace the call to OECM feature end point with requests to the …

### DIFF
--- a/app/helpers/map_helper.rb
+++ b/app/helpers/map_helper.rb
@@ -79,9 +79,10 @@ OVERLAYS = [
 ].freeze
 
 ALL_SERVICES_FOR_POINT_QUERY = [
-  { url: OECM_FEATURE_SERVER_LAYER_URL, isPoint: false },
+  { url: WDPA_POLY_LAYER_URL, isPoint: false },
   { url: WDPA_POINT_LAYER_URL, isPoint: true },
-  { url: WDPA_POLY_LAYER_URL, isPoint: false }
+  { url: OECM_POINT_LAYER_URL, isPoint: true },
+  { url: OECM_POLY_LAYER_URL, isPoint: false }
 ].freeze
 
 module MapHelper


### PR DESCRIPTION
https://unep-wcmc.codebasehq.com/projects/protected-planet-support-and-maintenance/tickets/286

Clicking on OECMs on the map on the home page didn't work

this PR changes the FeatureSerice endpoint we were querying for two MapServer endpoints (polygon and point)

Testing:
On home page, click on different PA types, each should cause a popup, and the link should take you to the show page for that PA