### PR TITLE
fix: calculate the edge length of squares in the coverage diagrams

### DIFF
--- a/app/javascript/components/stats/StatsCoverage.vue
+++ b/app/javascript/components/stats/StatsCoverage.vue
@@ -7,8 +7,8 @@
         <div class="chart--square">
           <span 
             :class="`chart__area theme--${type}`" 
-            :style="`width: ${protectedPercentage}%; height: ${protectedPercentage}%;`"
-          ></span>
+            :style="`width: ${ squareEdgeLength(protectedPercentage) }%; height: ${ squareEdgeLength(protectedPercentage) }%;`"
+          />
         </div>
       </div>
 
@@ -123,6 +123,12 @@ export default {
     
     hasPameData () {
       return this.pamePercentage != null && this.pameKm2 != null
+    }
+  },
+
+  methods: {
+    squareEdgeLength (percentage) {
+      return Math.sqrt(percentage * 100)
     }
   }
 }


### PR DESCRIPTION
https://unep-wcmc.codebasehq.com/projects/protected-planet-support-and-maintenance/tickets/288

testing:
go to country or region show pages and look at the square coverage diagrams. 
LUX has highest `http://localhost:3000/country/LUX`