### PR TITLE
fix: reduce complexity of geojson before sending to mapbox in uri, to …

### DIFF
--- a/app/models/concerns/geometry_concern.rb
+++ b/app/models/concerns/geometry_concern.rb
@@ -22,14 +22,67 @@ module GeometryConcern
     ]
   end
 
+  def geojson_for_mapbox_uri geo_properties=nil
+    # Returns a stringified geojson for making a request to the Mapbox API, to generate a preview thumbnail.
+    # If the string is too long it will be rejected, so we then need to simplify it.
+    # First we can buffer it, which reduces complexity but retains the original shape well.
+    # Finally, if the string is still too long, we fall back on a convex transformation, which
+    # provides a very crude outline, but is a short string.
+    if geojson_suitable_for_mapbox_url?((geojson = geojson_query(geo_properties)))
+      geojson
+    elsif geojson_suitable_for_mapbox_url?((buffered_geojson = buffered_geojson_query(geo_properties)))
+      buffered_geojson
+    else
+      convex_geojson_query(geo_properties)
+    end
+  end
+
+  def geojson_suitable_for_mapbox_url?(geojson)
+    geojson.present? && geojson.length <= 5000
+  end
+
   def geojson geo_properties=nil
-    geojson = ActiveRecord::Base.connection.select_value("""
-      SELECT ST_AsGeoJSON(ST_SimplifyPreserveTopology(ST_MakeValid(#{main_geom_column}), 0.003), 3)
+    geojson_query(geo_properties)
+  end
+
+  private
+
+  def buffered_geojson_query geo_properties
+    # We send a geojson to mapbox to create thumbnails. If the length of these exceeds a uri
+    # length of ~5000 characters, mapbox returns a 403. This method simplifies the geojson by
+    # first simplifying the geometry (to make the buffer faster), adding a buffer, and then
+    # simplifying again.
+    simplified_geojson = ActiveRecord::Base.connection.select_value("""
+    SELECT ST_AsGeoJSON(ST_SimplifyPreserveTopology(ST_Buffer(ST_SimplifyPreserveTopology(ST_MakeValid(#{main_geom_column}), 0.005), 0.005), 0.005), 3)
       FROM #{self.class.table_name}
       WHERE id = #{id}
     """.squish)
 
-    return nil unless geojson.present?
+    simplified_geojson.present? ? to_uri(simplified_geojson, geo_properties) : nil
+  end
+
+  def convex_geojson_query geo_properties
+    # Very simple polygon, if other polygon thumbnail methods fail.
+    simplified_geojson = ActiveRecord::Base.connection.select_value("""
+    SELECT ST_AsGeoJSON(ST_ConvexHull(ST_MakeValid(#{main_geom_column})), 3)
+      FROM #{self.class.table_name}
+      WHERE id = #{id}
+    """.squish)
+
+    simplified_geojson.present? ? to_uri(simplified_geojson, geo_properties) : nil
+  end
+
+  def geojson_query(geo_properties)
+    simplified_geojson = ActiveRecord::Base.connection.select_value("""
+    SELECT ST_AsGeoJSON(ST_SimplifyPreserveTopology(ST_MakeValid(#{main_geom_column}), 0.003), 3)
+      FROM #{self.class.table_name}
+      WHERE id = #{id}
+    """.squish)
+
+    simplified_geojson.present? ? to_uri(simplified_geojson, geo_properties) : nil
+  end
+
+  def to_uri(geojson, geo_properties=nil)
     geometry = JSON.parse(geojson)
 
     URI.encode({
@@ -38,8 +91,6 @@ module GeometryConcern
       "geometry" => geometry
     }.to_json)
   end
-
-  private
 
   def geometry_properties
     if self.respond_to?(:marine) && marine

--- a/lib/modules/asset_generator.rb
+++ b/lib/modules/asset_generator.rb
@@ -5,7 +5,7 @@ module AssetGenerator
   def self.protected_area_tile protected_area
     raise AssetGenerationFailedError if protected_area.nil?
 
-    tile_url = mapbox_url protected_area.geojson
+    tile_url = mapbox_url protected_area.geojson_for_mapbox_uri
     request_tile tile_url
   rescue AssetGenerationFailedError
     ''#fallback_tile
@@ -42,8 +42,6 @@ module AssetGenerator
     
     tile_url = base_url + "geojson(#{geojson})/auto/#{size[:x]}x#{size[:y]}@2x"
     tile_url << "?access_token=#{access_token}"
-
-    
   end
 
   def self.request_tile tile_url


### PR DESCRIPTION
…prevent 403 error from mapbox

https://unep-wcmc.codebasehq.com/projects/protected-planet-support-and-maintenance/tickets/131
https://unep-wcmc.codebasehq.com/projects/protected-planet-support-and-maintenance/tickets/203
https://unep-wcmc.codebasehq.com/projects/protected-planet-support-and-maintenance/tickets/271

mapbox was rejecting requests becuase the geojson in the uri made it too long (somewhere over 5000 characters), so thumbnails weren't being generated for PAs with complex geometries

this simplifies the geometry before sending if the PAs geometry is too complex and, if that doesn't simplify enough, uses a very simple outline simplification. 

testing:
put a byebug on line 11 of the AssetGenerator class (which will be hit if any of the tile requests fails)
go to ```http://localhost:3000/en/search-areas?search_term=wales&geo_type=site```
all thumbnails should load
go to http://localhost:3000/en/search-areas?filters%5Bdb_type%5D%5B%5D=wdpa and keep scrolling and let the thumbnails load, should not hit the byebug