### PR TITLE
fix: update disclaimer text

### DIFF
--- a/app/assets/stylesheets/components/maps/_v-map-disclaimer.scss
+++ b/app/assets/stylesheets/components/maps/_v-map-disclaimer.scss
@@ -21,6 +21,11 @@
     }
   }
 
+  &__body {
+    overflow-y: auto;
+    max-height: 14em;
+  }
+
   &--embedded {
     &.v-map-disclaimer {
       background: transparent;

--- a/config/locales/map/en.yml
+++ b/config/locales/map/en.yml
@@ -17,7 +17,11 @@ en:
     title_oecm: Discover OECMs
     disclaimer:
       heading: Map Disclaimer
-      body: The designations employed and the presentation of material on this map do not imply the expression of any opinion whatsoever on the part of the Secretariat of the United Nations concerning the legal status of any country, territory, city or area or of its authorities, or concerning the delimitation of its frontiers or boundaries. Final status of the Abyei area is not yet determined.
+      body: The designations employed and the presentation of material on this map do not imply the expression of any opinion whatsoever on the part of the Secretariat of the UnitedNations concerning the legal status of any country, territory, city or area or of its authorities, or concerning the delimitation of its frontiers or boundaries.<br><br>
+        &#8226; Dotted line represents approximately the Line of Control in Jammu and Kashmir agreed upon by India and Pakistan. The final status of Jammu and Kashmir has not yet been agreed upon by the parties.<br>
+        &#8226; Final boundary between the Republic of Sudan and the Republic of South Sudan has not yet been determined.<br>
+        &#8226; Final status of the Abyei area is not yet determined.<br>
+        &#8226; A dispute exists between the Governments of Argentina and the United Kingdom of Great Britain and Northern Ireland concerning sovereignty over the Falkland Islands (Malvinas).
     autocomplete_error_messages:
       no_results: No results.
       invalid_search_string: Type a minimum of 3 characters.

--- a/config/locales/map/en.yml
+++ b/config/locales/map/en.yml
@@ -17,7 +17,7 @@ en:
     title_oecm: Discover OECMs
     disclaimer:
       heading: Map Disclaimer
-      body: The designations employed and the presentation of material on this map do not imply the expression of any opinion whatsoever on the part of the Secretariat of the UnitedNations concerning the legal status of any country, territory, city or area or of its authorities, or concerning the delimitation of its frontiers or boundaries.<br><br>
+      body: The designations employed and the presentation of material on this map do not imply the expression of any opinion whatsoever on the part of the Secretariat of the United Nations concerning the legal status of any country, territory, city or area or of its authorities, or concerning the delimitation of its frontiers or boundaries.<br><br>
         &#8226; Dotted line represents approximately the Line of Control in Jammu and Kashmir agreed upon by India and Pakistan. The final status of Jammu and Kashmir has not yet been agreed upon by the parties.<br>
         &#8226; Final boundary between the Republic of Sudan and the Republic of South Sudan has not yet been determined.<br>
         &#8226; Final status of the Abyei area is not yet determined.<br>


### PR DESCRIPTION
This PR update the text for the disclaimer on the map. To test it, run the app and the new disclaimer should show:
```
The designations employed and the presentation of material on this map do not imply the expression of any opinion whatsoever on the part of the Secretariat of the UnitedNations concerning the legal status of any country, territory, city or area or of its authorities, or concerning the delimitation of its frontiers or boundaries.

- Dotted line represents approximately the Line of Control in Jammu and Kashmir agreed upon by India and Pakistan. The final status of Jammu and Kashmir has not yet been agreed upon by the parties.
- Final boundary between the Republic of Sudan and the Republic of South Sudan has not yet been determined.
- Final status of the Abyei area is not yet determined.
- A dispute exists between the Governments of Argentina and the United Kingdom of Great Britain and Northern Ireland concerning sovereignty over the Falkland Islands (Malvinas).```