### PR TITLE
fix: pa count

### DIFF
--- a/app/models/region.rb
+++ b/app/models/region.rb
@@ -6,7 +6,7 @@ class Region < ApplicationRecord
   include SourceHelper
 
   has_many :countries
-  has_many :protected_areas, through: :countries
+  has_many :protected_areas, -> { distinct }, through: :countries
   has_many :designations, -> { distinct }, through: :protected_areas
   has_many :iucn_categories, through: :protected_areas
 


### PR DESCRIPTION
PAs shared between two countries within the same region are counted twice in the regional statistics

e.g. https://www.protectedplanet.net/region/na
number of PAs 52727
number of unique PAs 52725