### PR TITLE
feat: remove buffer query which might be too slow? possible fix for t…

### DIFF
--- a/app/models/concerns/geometry_concern.rb
+++ b/app/models/concerns/geometry_concern.rb
@@ -26,7 +26,8 @@ module GeometryConcern
     # Returns a stringified geojson for making a request to the Mapbox API, to generate a preview thumbnail.
     # If the string is too long it will be rejected, so we then need to simplify it.
     # We fall back on a convex transformation, which provides a very crude outline, but is a short string.
-    if geojson_suitable_for_mapbox_url?((geojson = geojson_query(geo_properties)))
+    geojson = geojson_query(geo_properties)
+    if geojson_suitable_for_mapbox_url?(geojson)
       geojson
     else
       convex_geojson_query(geo_properties)


### PR DESCRIPTION
…he SQL database connection issue on production

This change was introduced before the recent SQL errors on production. I'm wondering if the buffering postgis functions are taking a long time, and if that is causing the connections to max out.

It was intended as a bug fix, where thumbnail previews of protected areas were not being generated. the bug happened because we use a mapbox API to generate the previews by posting a string of coordinates. when the uri containing the coordinates gets too long, mapbox fails, so no preview was being returned. the original fix included two methods to reduce the number of coordinates if the original coordinates were too long. the first uses buffering to maintain the shape of the polygons, but might be quite slow. the second is faster but alters the shape of the polygon.

This PR removes the slower request, leaving the more simple one. The effect will be some previews in the cards will not look as good. This should not be a problem, because it was stated in a ticket that this was ok (there were several for this bug)