### PR TITLE
fix: revert mapbox geojson simplification methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 4.8.27
+- Revert geojson simplification methods for mapbox
+
 ### 4.8.26
 - Chore: Jan 2023 WDPA Release
   - Jan statistics CSVs added: `country_statistics`, `global_statistics`, `pame_country`, `pame_data`

--- a/app/models/concerns/geometry_concern.rb
+++ b/app/models/concerns/geometry_concern.rb
@@ -22,67 +22,14 @@ module GeometryConcern
     ]
   end
 
-  def geojson_for_mapbox_uri geo_properties=nil
-    # Returns a stringified geojson for making a request to the Mapbox API, to generate a preview thumbnail.
-    # If the string is too long it will be rejected, so we then need to simplify it.
-    # First we can buffer it, which reduces complexity but retains the original shape well.
-    # Finally, if the string is still too long, we fall back on a convex transformation, which
-    # provides a very crude outline, but is a short string.
-    if geojson_suitable_for_mapbox_url?((geojson = geojson_query(geo_properties)))
-      geojson
-    elsif geojson_suitable_for_mapbox_url?((buffered_geojson = buffered_geojson_query(geo_properties)))
-      buffered_geojson
-    else
-      convex_geojson_query(geo_properties)
-    end
-  end
-
-  def geojson_suitable_for_mapbox_url?(geojson)
-    geojson.present? && geojson.length <= 5000
-  end
-
   def geojson geo_properties=nil
-    geojson_query(geo_properties)
-  end
-
-  private
-
-  def buffered_geojson_query geo_properties
-    # We send a geojson to mapbox to create thumbnails. If the length of these exceeds a uri
-    # length of ~5000 characters, mapbox returns a 403. This method simplifies the geojson by
-    # first simplifying the geometry (to make the buffer faster), adding a buffer, and then
-    # simplifying again.
-    simplified_geojson = ActiveRecord::Base.connection.select_value("""
-    SELECT ST_AsGeoJSON(ST_SimplifyPreserveTopology(ST_Buffer(ST_SimplifyPreserveTopology(ST_MakeValid(#{main_geom_column}), 0.005), 0.005), 0.005), 3)
+    geojson = ActiveRecord::Base.connection.select_value("""
+      SELECT ST_AsGeoJSON(ST_SimplifyPreserveTopology(ST_MakeValid(#{main_geom_column}), 0.003), 3)
       FROM #{self.class.table_name}
       WHERE id = #{id}
     """.squish)
 
-    simplified_geojson.present? ? to_uri(simplified_geojson, geo_properties) : nil
-  end
-
-  def convex_geojson_query geo_properties
-    # Very simple polygon, if other polygon thumbnail methods fail.
-    simplified_geojson = ActiveRecord::Base.connection.select_value("""
-    SELECT ST_AsGeoJSON(ST_ConvexHull(ST_MakeValid(#{main_geom_column})), 3)
-      FROM #{self.class.table_name}
-      WHERE id = #{id}
-    """.squish)
-
-    simplified_geojson.present? ? to_uri(simplified_geojson, geo_properties) : nil
-  end
-
-  def geojson_query(geo_properties)
-    simplified_geojson = ActiveRecord::Base.connection.select_value("""
-    SELECT ST_AsGeoJSON(ST_SimplifyPreserveTopology(ST_MakeValid(#{main_geom_column}), 0.003), 3)
-      FROM #{self.class.table_name}
-      WHERE id = #{id}
-    """.squish)
-
-    simplified_geojson.present? ? to_uri(simplified_geojson, geo_properties) : nil
-  end
-
-  def to_uri(geojson, geo_properties=nil)
+    return nil unless geojson.present?
     geometry = JSON.parse(geojson)
 
     URI.encode({
@@ -91,6 +38,8 @@ module GeometryConcern
       "geometry" => geometry
     }.to_json)
   end
+
+  private
 
   def geometry_properties
     if self.respond_to?(:marine) && marine

--- a/lib/modules/asset_generator.rb
+++ b/lib/modules/asset_generator.rb
@@ -5,7 +5,7 @@ module AssetGenerator
   def self.protected_area_tile protected_area
     raise AssetGenerationFailedError if protected_area.nil?
 
-    tile_url = mapbox_url protected_area.geojson_for_mapbox_uri
+    tile_url = mapbox_url protected_area.geojson
     request_tile tile_url
   rescue AssetGenerationFailedError
     ''#fallback_tile


### PR DESCRIPTION
needs to go to master because develop has new features on it.

Restores previous method of generating mapbox thumbnails. will fail on very large geojsons, as before.

Testing:
go to http://localhost:3000/en/search-areas?filters%5Bdb_type%5D%5B%5D=wdpa
thumbnails should load as you scroll down the page