### PR TITLE
Make PAME stats consistent within PP and PP API

### DIFF
--- a/app/controllers/country_controller.rb
+++ b/app/controllers/country_controller.rb
@@ -17,7 +17,8 @@ class CountryController < ApplicationController
 
     @flag_path = flag_path(@country.name)
 
-    @total_pame = @country.protected_areas.with_pame_evaluations.count
+    # exclude transboundary PAs where the PAME evaluation is associated only with another country
+    @total_pame = @country.protected_areas.with_pame_evaluations.includes(pame_evaluations: :countries).where(pame_evaluations: {countries: {id: @country.id}}).count
     @total_wdpa = @country.protected_areas.wdpas.count
 
     @map = {

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -33,19 +33,19 @@ class Country < ApplicationRecord
   def assessments
     # join protected_area table to exclude PAME evaluations where wdpa_id doesn't exist anymore or the site is restricted
     # count PAME evaluations of protected areas within the given country - excluding overseas territories
-    pame_evaluations.joins(protected_area: :countries).where(countries: {id: id}).count +
+    return pame_evaluations.joins(protected_area: :countries).where(countries: {id: id}).count if country_id.nil?
     # protected areas located in the overseas territories have PAME evaluations reported by their parent country
     # look up the parent country and count PAME evaluations for the given overseas territory
-    (parent&.pame_evaluations&.joins(protected_area: :countries)&.where(countries: {id: id})&.count || 0)
+    parent&.pame_evaluations&.joins(protected_area: :countries)&.where(countries: {id: id})&.count
   end
 
   def assessed_pas
     # join protected_area table to exclude PAME evaluations where wdpa_id doesn't exist anymore or the site is restricted
     # count protected areas with PAME evaluations within the given country - excluding overseas territories
-    pame_evaluations.joins(protected_area: :countries).where(countries: {id: id})&.pluck(:protected_area_id).uniq.count +
+    return pame_evaluations.joins(protected_area: :countries).where(countries: {id: id})&.pluck(:protected_area_id).uniq.count if country_id.nil?
     # protected areas located in the overseas territories have PAME evaluations reported by their parent country
     # look up the parent country and count protected areas with PAME evaluations for the given overseas territory
-    (parent&.pame_evaluations&.joins(protected_area: :countries)&.where(countries: {id: id})&.pluck(:protected_area_id)&.uniq&.count || 0)
+    parent&.pame_evaluations&.joins(protected_area: :countries)&.where(countries: {id: id})&.pluck(:protected_area_id)&.uniq&.count
   end
 
   def protected_areas_with_iucn_categories

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -31,11 +31,11 @@ class Country < ApplicationRecord
   end
 
   def assessments
-    pame_evaluations.count
+    pame_evaluations.select{|pe| pe[:protected_area_id]}.count
   end
 
   def assessed_pas
-    pame_evaluations.map(&:wdpa_id).uniq.count
+    pame_evaluations.select{|pe| pe[:protected_area_id]}.map(&:wdpa_id).uniq.count
   end
 
   def protected_areas_with_iucn_categories

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -31,13 +31,11 @@ class Country < ApplicationRecord
   end
 
   def assessments
-    # count excluding overseas territories 
-    pame_evaluations.joins(protected_area: :countries).where(countries: {id: id}).count + (parent&.pame_evaluations&.joins(protected_area: :countries)&.where(countries: {id: id})&.count || 0) # overseas territories only
+    protected_areas.joins(:pame_evaluations).count
   end
 
   def assessed_pas
-    # count excluding overseas territories 
-    pame_evaluations.joins(protected_area: :countries).where(countries: {id: id})&.pluck(:protected_area_id).uniq.count + (parent&.pame_evaluations&.joins(protected_area: :countries)&.where(countries: {id: id})&.pluck(:protected_area_id)&.uniq&.count || 0) # overseas territories only
+    protected_areas.joins(:pame_evaluations).pluck(:wdpa_id).uniq.count
   end
 
   def protected_areas_with_iucn_categories

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -31,11 +31,17 @@ class Country < ApplicationRecord
   end
 
   def assessments
-    protected_areas.joins(:pame_evaluations).count
+    # count excluding overseas territories
+    pame_evaluations.joins(protected_area: :countries).where(countries: {id: id}).count +
+    # overseas territories only
+    (parent&.pame_evaluations&.joins(protected_area: :countries)&.where(countries: {id: id})&.count || 0)
   end
 
   def assessed_pas
-    protected_areas.joins(:pame_evaluations).pluck(:wdpa_id).uniq.count
+    # count excluding overseas territories
+    pame_evaluations.joins(protected_area: :countries).where(countries: {id: id})&.pluck(:protected_area_id).uniq.count +
+    # overseas territories only
+    (parent&.pame_evaluations&.joins(protected_area: :countries)&.where(countries: {id: id})&.pluck(:protected_area_id)&.uniq&.count || 0)
   end
 
   def protected_areas_with_iucn_categories

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -31,16 +31,20 @@ class Country < ApplicationRecord
   end
 
   def assessments
-    # count excluding overseas territories
+    # join protected_area table to exclude PAME evaluations where wdpa_id doesn't exist anymore or the site is restricted
+    # count PAME evaluations of protected areas within the given country - excluding overseas territories
     pame_evaluations.joins(protected_area: :countries).where(countries: {id: id}).count +
-    # overseas territories only
+    # protected areas located in the overseas territories have PAME evaluations reported by their parent country
+    # look up the parent country and count PAME evaluations for the given overseas territory
     (parent&.pame_evaluations&.joins(protected_area: :countries)&.where(countries: {id: id})&.count || 0)
   end
 
   def assessed_pas
-    # count excluding overseas territories
+    # join protected_area table to exclude PAME evaluations where wdpa_id doesn't exist anymore or the site is restricted
+    # count protected areas with PAME evaluations within the given country - excluding overseas territories
     pame_evaluations.joins(protected_area: :countries).where(countries: {id: id})&.pluck(:protected_area_id).uniq.count +
-    # overseas territories only
+    # protected areas located in the overseas territories have PAME evaluations reported by their parent country
+    # look up the parent country and count protected areas with PAME evaluations for the given overseas territory
     (parent&.pame_evaluations&.joins(protected_area: :countries)&.where(countries: {id: id})&.pluck(:protected_area_id)&.uniq&.count || 0)
   end
 

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -31,11 +31,13 @@ class Country < ApplicationRecord
   end
 
   def assessments
-    pame_evaluations.select{|pe| pe[:protected_area_id]}.count
+    # count excluding overseas territories 
+    pame_evaluations.joins(protected_area: :countries).where(countries: {id: id}).count + (parent&.pame_evaluations&.joins(protected_area: :countries)&.where(countries: {id: id})&.count || 0) # overseas territories only
   end
 
   def assessed_pas
-    pame_evaluations.select{|pe| pe[:protected_area_id]}.map(&:wdpa_id).uniq.count
+    # count excluding overseas territories 
+    pame_evaluations.joins(protected_area: :countries).where(countries: {id: id})&.pluck(:protected_area_id).uniq.count + (parent&.pame_evaluations&.joins(protected_area: :countries)&.where(countries: {id: id})&.pluck(:protected_area_id)&.uniq&.count || 0) # overseas territories only
   end
 
   def protected_areas_with_iucn_categories

--- a/app/models/pame_evaluation.rb
+++ b/app/models/pame_evaluation.rb
@@ -89,9 +89,9 @@ class PameEvaluation < ApplicationRecord
         site_ids << countries.map{ |iso3| Country.find_by(iso_3: iso3).protected_areas.pluck(:id) }
         where_params[:sites] = site_ids.flatten.empty? ? nil : "pame_evaluations.protected_area_id IN (#{site_ids.join(',')})"
         country_ids << countries.map { |iso3|
-          c = Country.find_by(iso_3: iso3)
+          country = Country.find_by(iso_3: iso3)
           # include the parent country id for the overseas territory because PAME evaluation is assigned to the parent country
-          c.country_id? ? [c.id, c.country_id] : c.id
+          [country.id, country.country_id].compact
         }
         where_params[:iso3] = country_ids.flatten.empty? ? nil : "countries.id IN (#{country_ids.join(',')})"
       when 'methodology'

--- a/app/models/pame_evaluation.rb
+++ b/app/models/pame_evaluation.rb
@@ -88,7 +88,11 @@ class PameEvaluation < ApplicationRecord
         countries = options
         site_ids << countries.map{ |iso3| Country.find_by(iso_3: iso3).protected_areas.pluck(:id) }
         where_params[:sites] = site_ids.flatten.empty? ? nil : "pame_evaluations.protected_area_id IN (#{site_ids.join(',')})"
-        country_ids << countries.map{ |iso3| "#{ Country.find_by(iso_3: iso3).id }" }
+        country_ids << countries.map { |iso3|
+          c = Country.find_by(iso_3: iso3)
+          # include the parent country id for the overseas territory because PAME evaluation is assigned to the parent country
+          c.country_id? ? [c.id, c.country_id] : c.id
+        }
         where_params[:iso3] = country_ids.flatten.empty? ? nil : "countries.id IN (#{country_ids.join(',')})"
       when 'methodology'
         options = options.map{ |e| "'#{e}'" }

--- a/app/models/pame_evaluation.rb
+++ b/app/models/pame_evaluation.rb
@@ -108,7 +108,7 @@ class PameEvaluation < ApplicationRecord
   def self.run_query(page, where_params)
     if where_params[:sites].present?
       query = PameEvaluation.connection.unprepared_statement {
-        "((#{pame_evaluations_from_pa_query(where_params)}) UNION (#{pame_evaluations_from_countries_query(where_params)})) AS pame_evaluations"
+        "(#{pame_evaluations_from_pa_query(where_params)}) AS pame_evaluations"
       }
 
       PameEvaluation
@@ -126,21 +126,12 @@ class PameEvaluation < ApplicationRecord
 
   def self.pame_evaluations_from_pa_query(where_params)
     PameEvaluation
-    .joins(:protected_area)
+    .joins(:protected_area, :countries)
     .where(where_params[:sites])
     .where(where_params[:methodology])
     .where(where_params[:year])
     .where(where_params[:type])
-    .to_sql
-  end
-
-  def self.pame_evaluations_from_countries_query(where_params)
-    PameEvaluation
-    .joins(:countries)
     .where(where_params[:iso3])
-    .where(where_params[:methodology])
-    .where(where_params[:year])
-    .where(where_params[:type])
     .to_sql
   end
 

--- a/lib/modules/wdpa/pame_importer.rb
+++ b/lib/modules/wdpa/pame_importer.rb
@@ -74,7 +74,7 @@ module Wdpa::PameImporter
         hidden_evaluations << wdpa_id unless restricted
       end
 
-      iso3s.split(',').each do |iso3|
+      iso3s.split(';').each do |iso3|
         country = Country.find_by(iso_3: iso3)
         if country.present?
           pame_evaluation.countries << country unless pame_evaluation.countries.include? country


### PR DESCRIPTION
## Bug ticket:
https://unep-wcmc.codebasehq.com/projects/data-infrastructure-refactor/tickets/196

[notes for context](https://github.com/unepwcmc/ProtectedPlanet/wiki/PAME-Evaluation-Notes)

PAME Evaluations for a given country are shown in different places:
- [Country page](https://www.protectedplanet.net/country/FRA)
- [PAME table](https://www.protectedplanet.net/en/thematic-areas/protected-areas-management-effectiveness-pame?tab=Results)
- API (pame_statistic.assessments)

# Testing:
1. Run `ImportTools.statistics_monthly_import` 
2. Check that transboundary sites are excluded from the count if only the other country has PAME evaluation assigned (e.g. POL-BLR, wdpa_id: 2008)
3. Check that PAME table doesn't include overseas territories (e.g FRA)
4. Check that regional statistics are unchanged