### PR TITLE
feat: add 2 more tabs

### DIFF
--- a/app/controllers/concerns/tabs.rb
+++ b/app/controllers/concerns/tabs.rb
@@ -2,14 +2,18 @@ module Concerns::Tabs
   extend ActiveSupport::Concern
   included do
     include Comfy::CmsHelper
-    
-    def get_tabs total_tabs
-      tabs = []
 
+    def get_tabs(total_tabs, skip_tabs_with_empty_content = false)
+      tabs = []
       total_tabs.times do |i|
+        id = i + 1
+        content_id = "tab-content-#{id}"
+        content = cms_fragment_content(content_id, @cms_page)
+        next if skip_tabs_with_empty_content == true && (content.nil? == true || content.empty? == true)
         tab = {
-          id: i+1,
-          title: cms_fragment_content(:"tab-title-#{i+1}", @cms_page)
+          id: id,
+          title: cms_fragment_content(:"tab-title-#{i + 1}", @cms_page),
+          content_id: content_id
         }
 
         tabs << tab

--- a/app/controllers/oecm_controller.rb
+++ b/app/controllers/oecm_controller.rb
@@ -5,14 +5,15 @@ class OecmController < ApplicationController
   def index
     @oecm_coverage_percentage = GlobalStatistic.global_oecms_pas_coverage_percentage
 
-    @download_options = helpers.download_options(['csv', 'shp', 'gdb', 'esri_oecm'], 'general', 'oecm')
+    @download_options = helpers.download_options(%w[csv shp gdb esri_oecm], 'general', 'oecm')
 
     @config_search_areas = {
       id: 'oecm',
       placeholder: I18n.t('global.placeholder.search-oecm')
     }.to_json
 
-    @tabs = get_tabs(3).to_json
+    @tabs_list = get_tabs(5, true)
+    @tabs = @tabs_list.to_json
 
     @map = {
       overlays: MapOverlaysSerializer.new(oecm_overlays, map_yml).serialize,
@@ -21,7 +22,7 @@ class OecmController < ApplicationController
       point_query_services: oecm_services_for_point_query
     }
     @map_options = {
-      map: { center: [-100,0] }
+      map: { center: [-100, 0] }
     }
     @filters = { db_type: ['oecm'] }
   end
@@ -30,7 +31,7 @@ class OecmController < ApplicationController
 
   def oecm_overlays
     overlays(['oecm'], {
-      'oecm': {
+      oecm: {
         isToggleable: false
       }
     })

--- a/app/controllers/wdpa_controller.rb
+++ b/app/controllers/wdpa_controller.rb
@@ -13,8 +13,8 @@ class WdpaController < ApplicationController
     }.to_json
 
     @filters = { db_type: ['wdpa'] }
-
-    @tabs = get_tabs(3).to_json
+    @tabs_list = get_tabs(5, true)
+    @tabs = @tabs_list.to_json
 
     @map = {
       overlays: MapOverlaysSerializer.new(wdpa_overlays, map_yml).serialize,

--- a/app/views/oecm/index.html.erb
+++ b/app/views/oecm/index.html.erb
@@ -17,7 +17,8 @@
   ga_id: "Slug: #{@cms_page.slug}",
   map: @map,
   map_options: @map_options,
-  tabs: @tabs
+  tabs_json: @tabs,
+  tabs_list: @tabs_list,
 } %>
 
 <section class="container spacer-small--top">

--- a/app/views/partials/tabs/_tabs-thematic-area-database.html.erb
+++ b/app/views/partials/tabs/_tabs-thematic-area-database.html.erb
@@ -2,36 +2,35 @@
   class="tabs--hero"
   ga-id="<%= ga_id %>"
   preselected-tab="<%= params[:tab] %>"
-  :tab-triggers="<%= tabs %>"
+  :tab-triggers="<%= tabs_json %>"
 >
   <template slot-scope="slotProps">
-    <tab-target :id="1" :selected-id="slotProps.selectedId">
-      <section class="container--medium">
-        <%= cms_fragment_render("tab-content-1") %>
-      </section>
-
-      <section class="spacer-large--bottom">
-        <%= render partial: "partials/search/protected-areas", locals: { config: config_search } %>
-      </section>
-
-      <section class="map-section">
-        <%= render partial: "partials/maps/main", locals: {
+    <%# If the senario are more complicated then you will need to render each tab by yourself so you have more freedom to change content in each tab %>
+    <% tabs_list.each do |tab|%>
+      <% @tab_element_id = tab[:id].to_json %>
+      <% @thematic_area_database_tab_cms_content = cms_fragment_render(tab[:content_id]) %>
+      <% if tab[:id] == 1 %>
+        <tab-target :id=<%= @tab_element_id %> :selected-id="slotProps.selectedId">
+          <section class="container--medium">
+            <%= @thematic_area_database_tab_cms_content %>
+          </section>
+          <section class="spacer-large--bottom">
+            <%= render partial: "partials/search/protected-areas", locals: { config: config_search } %>
+          </section>
+          <section class="map-section">
+            <%= render partial: "partials/maps/main", locals: {
           map: map,
           map_options: local_assigns.has_key?(:map_options) ? map_options : nil
         } %>
-      </section>
-    </tab-target>
-
-    <tab-target :id="2" :selected-id="slotProps.selectedId">
-      <section class="container--medium">
-        <%= cms_fragment_render("tab-content-2") %>
-      </section>
-    </tab-target>
-
-    <tab-target :id="3" :selected-id="slotProps.selectedId">
-      <section class="container--medium">
-        <%= cms_fragment_render("tab-content-3") %>
-      </section>
-    </tab-target>
+          </section>
+        </tab-target>
+      <% else %>
+        <tab-target :id=<%= @tab_element_id %> :selected-id="slotProps.selectedId">
+          <section class="container--medium">
+            <%= @thematic_area_database_tab_cms_content %>
+          </section>
+        </tab-target>
+      <% end %>
+    <% end %>
   </template>
 </tabs>

--- a/app/views/wdpa/index.html.erb
+++ b/app/views/wdpa/index.html.erb
@@ -16,7 +16,8 @@
   config_search: @config_search_areas,
   ga_id: "Slug: #{@cms_page.slug}",
   map: @map,
-  tabs: @tabs
+  tabs_json: @tabs,
+  tabs_list: @tabs_list,
 } %>
 
 <section class="container spacer-small--top">


### PR DESCRIPTION
- Add two extra columns in the comfy CMS for WDPA and OECM Thematic Area page
- [Planner ticket](https://planner.cloud.microsoft/wcmc.onmicrosoft.com/Home/Task/ZJe8gg9tx0aQgY6UxrSFcZcAHc9L?Type=TaskLink&Channel=Link&CreatedTime=638626872948510000)
- Tabs (title) are hidden when no content in them
- It is now on staging server 
  - https://pp.new-web.pp-staging.linode.protectedplanet.net/thematic-areas/oecms?tab=OECMs
  - https://pp.new-web.pp-staging.linode.protectedplanet.net/thematic-areas/wdpa?tab=Tab5


