### PR TITLE
Feat/hook up download views

### DIFF
--- a/app/helpers/downloads_helper.rb
+++ b/app/helpers/downloads_helper.rb
@@ -90,7 +90,7 @@ module DownloadsHelper
   def citation_text
     # Reflects the month/year of the last monthly release
     begin
-      current_month_year = Date.parse(Wdpa::S3.current_wdpa_identifier)
+      current_month_year = Date.parse(Release.latest_succeeded_label)
     rescue TypeError, ArgumentError
       # If it can't parse it, falls back to the current date
       current_month_year = Time.now

--- a/app/models/aichi11_target.rb
+++ b/app/models/aichi11_target.rb
@@ -33,7 +33,7 @@ class Aichi11Target < ActiveRecord::Base
     end
   end
 
-  def self.update_live_table
+  def self.update_live_table(notifier: nil)
     ActiveRecord::Base.transaction do
       record = first || new
       was_created = !record.persisted?
@@ -55,6 +55,9 @@ class Aichi11Target < ActiveRecord::Base
         record.save!
         Rails.logger.info 'Aichi11Target: Created new record from CSV data'
       end
+
+      Rails.logger.info "Aichi11Target #{was_created ? 'created' : 'updated'} successfully"
+      notifier&.phase("Aichi11Target #{was_created ? 'created' : 'updated'} successfully")
 
       Wdpa::Shared::ImporterBase::Base.build_result(1, [], [], {
         action: was_created ? 'created' : 'updated',

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -7,5 +7,9 @@ class Release < ApplicationRecord
 
   validates :label, presence: true, uniqueness: true
   validates :state, inclusion: { in: STATES }
-end
 
+  # Returns the label of the most recently created Release that has succeeded
+  def self.latest_succeeded_label
+    where(state: 'succeeded').order(created_at: :desc).limit(1).pluck(:label).first
+  end
+end

--- a/app/services/portal_release/cleanup.rb
+++ b/app/services/portal_release/cleanup.rb
@@ -4,7 +4,7 @@ module PortalRelease
   class Cleanup
     class << self
       def post_swap!(log)
-        if ActiveModel::Type::Boolean.new.cast(ENV['PP_RELEASE_DRY_RUN'])
+        if ActiveModel::Type::Boolean.new.cast(ENV.fetch('PP_RELEASE_DRY_RUN', nil))
           # Analyze staging tables in dry-run for visibility
           [::Staging::ProtectedArea.table_name, ::Staging::ProtectedAreaParcel.table_name,
             ::Staging::Source.table_name].each do |t|
@@ -26,6 +26,9 @@ module PortalRelease
             # Rebuild searchable index to reflect new release data
             Search::Index.delete
             Search::Index.create
+
+            # Clear Rails cache to ensure fresh data is served
+            Rails.cache.clear
 
             log.event('post_swap_cleanup_done')
           rescue StandardError => e

--- a/app/services/portal_release/cleanup.rb
+++ b/app/services/portal_release/cleanup.rb
@@ -6,7 +6,8 @@ module PortalRelease
       def post_swap!(log)
         if ActiveModel::Type::Boolean.new.cast(ENV['PP_RELEASE_DRY_RUN'])
           # Analyze staging tables in dry-run for visibility
-          [::Staging::ProtectedArea.table_name, ::Staging::ProtectedAreaParcel.table_name, ::Staging::Source.table_name].each do |t|
+          [::Staging::ProtectedArea.table_name, ::Staging::ProtectedAreaParcel.table_name,
+            ::Staging::Source.table_name].each do |t|
             ActiveRecord::Base.connection.execute("ANALYZE #{t}")
           end
           log.event('post_swap_done_dry_run')
@@ -14,8 +15,18 @@ module PortalRelease
           # Delegate to core cleanup: VACUUM ANALYZE live tables and clean old backups
           begin
             Wdpa::Portal::Services::Core::TableCleanupService.cleanup_after_swap
-            # Drop any leftover temporary download views
-            Download::Generators::Base.clean_tmp_download_views
+
+            # the clean up is already done in create_portal_downloads_view! in app/services/portal_release/preflight.rb
+            # Please keep this here for historical reasons.
+            # Download::Generators::Base.clean_tmp_download_views
+
+            # Invalidate previously generated downloads so new requests regenerate against the new release
+            Download.clear_downloads
+
+            # Rebuild searchable index to reflect new release data
+            Search::Index.delete
+            Search::Index.create
+
             log.event('post_swap_cleanup_done')
           rescue StandardError => e
             Rails.logger.warn("Post-swap cleanup failed: #{e.class}: #{e.message}")
@@ -31,4 +42,3 @@ module PortalRelease
     end
   end
 end
-

--- a/app/services/portal_release/importer.rb
+++ b/app/services/portal_release/importer.rb
@@ -2,9 +2,10 @@
 
 module PortalRelease
   class Importer
-    def initialize(log, label:)
+    def initialize(log, label:, notifier: nil)
       @log = log
       @label = label
+      @notifier = notifier
     end
 
     def run_core!
@@ -21,7 +22,8 @@ module PortalRelease
         only: import_only,
         skip: import_skip,
         sample: import_sample,
-        label: @label
+        label: @label,
+        notifier: @notifier
       )
 
       @log.event('import_core_finished', payload: { success: results[:success], hard_errors: results[:hard_errors] })
@@ -34,4 +36,3 @@ module PortalRelease
     end
   end
 end
-

--- a/app/services/portal_release/notifier.rb
+++ b/app/services/portal_release/notifier.rb
@@ -219,7 +219,7 @@ module PortalRelease
       when 'finalise_swap'
         ['finalise_swap', 'Promote staging to live tables']
       when 'post_swap'
-        ['post_swap', 'Analyze tables and clear caches']
+        ['post_swap', 'Analyze tables and clear caches/reindex search index']
       when 'cleanup'
         ['cleanup', 'Retention and cleanup tasks']
       when 'cleanup_and_retention'

--- a/app/services/portal_release/notifier.rb
+++ b/app/services/portal_release/notifier.rb
@@ -19,16 +19,16 @@ module PortalRelease
     end
 
     def started(label)
-      post(":rocket: WDPA release #{label} started")
+      # Just to make a seperator on the slack channel
+      post("----------------------------")
+      post(":rocket: WDPA release #{label} started (#{Rails.env})")
     end
 
     # Generic phase text notifier; keep for backwards compatibility
     # If counts is a nested structure, we summarise it to avoid overly long Slack messages.
     def phase(text, counts: nil, tables: nil)
       extra = []
-      if counts
-        extra << summarise(counts)
-      end
+      extra << summarise(counts) if counts
       extra << tables&.join(', ') if tables
       post(":information_source: #{text} #{extra.compact.join(' | ')}")
     end
@@ -36,6 +36,7 @@ module PortalRelease
     # Explicit phase-complete notifier (can be silenced via env)
     def phase_complete(phase, duration_s: nil)
       return unless phase_notifications_enabled?
+
       suffix = duration_s ? " in #{format('%.1f', duration_s)}s" : ''
       title, expl = friendly_phase_and_explainer(phase)
       expl_text = expl ? " — #{expl}" : ''
@@ -48,6 +49,18 @@ module PortalRelease
 
     def error(e, phase:)
       post(":rotating_light: Release #{@label} failed in #{phase}: #{e.message}")
+    end
+
+    def progress(processed_count, total_estimated = nil, _phase = 'import')
+      return unless Wdpa::Portal::Config::PortalImportConfig.progress_notifications_enabled?
+
+      message = "It is now importing #{format_number(processed_count)} out of #{format_number(total_estimated)} protected areas"
+      post(":hourglass_flowing_sand: #{message}")
+    end
+
+    def import_completion(processed_count, _phase = 'import')
+      message = "Import completed: #{format_number(processed_count)} protected areas processed"
+      post(":white_check_mark: #{message}")
     end
 
     # Rollback notifications
@@ -85,6 +98,10 @@ module PortalRelease
       ActiveModel::Type::Boolean.new.cast(ENV['PP_RELEASE_SLACK_VERBOSE'])
     end
 
+    def format_number(number)
+      number.to_s.reverse.gsub(/(\d{3})(?=.)/, '\1,').reverse
+    end
+
     # Turn a nested Hash/Array structure (like importer results) into a concise summary string.
     # - Hashes are flattened using dot notation (e.g., sources.imported_count=514)
     # - Arrays are replaced by their counts; in verbose mode we add a small preview
@@ -120,6 +137,7 @@ module PortalRelease
 
     def summarise_array(key, arr)
       return "#{key}=0" if arr.nil? || arr.empty?
+
       if verbose?
         preview_count = (ENV['PP_RELEASE_SLACK_PREVIEW_COUNT'] || 5).to_i
         preview = arr.first(preview_count).map { |e| e.to_s }.join(', ')
@@ -133,6 +151,7 @@ module PortalRelease
     # Format a human-readable Block Kit card for the core importer results.
     # Focuses on the most meaningful metrics, no dot-notation.
     public
+
     def import_core_summary(results)
       ok = !!value(results, :success)
       hard_errors = Array(value(results, :hard_errors)).size
@@ -141,7 +160,8 @@ module PortalRelease
       src_count = value(results, :sources, :imported_count)
       pa_attrs = value(results, :protected_areas, :protected_areas_attributes, :imported_count)
       pa_geom_areas   = value(results, :protected_areas, :protected_areas_geometries, :protected_areas, :imported_count)
-      pa_geom_parcels = value(results, :protected_areas, :protected_areas_geometries, :protected_area_parcels, :imported_count)
+      pa_geom_parcels = value(results, :protected_areas, :protected_areas_geometries, :protected_area_parcels,
+        :imported_count)
       fields_updated = value(results, :global_stats, :fields_updated)
 
       gl_imported   = value(results, :green_list, :imported_count)
@@ -154,8 +174,8 @@ module PortalRelease
 
       blocks = [
         { type: 'header', text: { type: 'plain_text', text: "Import core — #{status_text}", emoji: true } },
-        { type: 'context', elements: [ { type: 'mrkdwn', text: "Label: `#{@label}` · Hard errors: #{hard_errors}" } ] },
-        { type: 'section', text: { type: 'mrkdwn', text: "*Summary*" } },
+        { type: 'context', elements: [{ type: 'mrkdwn', text: "Label: `#{@label}` · Hard errors: #{hard_errors}" }] },
+        { type: 'section', text: { type: 'mrkdwn', text: '*Summary*' } },
         {
           type: 'section',
           fields: [
@@ -163,13 +183,15 @@ module PortalRelease
             { type: 'mrkdwn', text: "*Protected areas imported*\n#{pa_attrs || 0}" },
             { type: 'mrkdwn', text: "*Geometries (areas/parcels)*\n#{pa_geom_areas || 0} / #{pa_geom_parcels || 0}" },
             { type: 'mrkdwn', text: "*Global statistics fields updated*\n#{fields_updated || 0}" },
-            { type: 'mrkdwn', text: "*Green List*\n#{gl_imported || 0} (Not found #{gl_not_found}, Invalid #{gl_invalid}#{gl_duplicates.positive? ? ", Duplicates #{gl_duplicates}" : ''})" },
-            { type: 'mrkdwn', text: "*PAME*\n#{pame_imported || 0}#{pame_unrec.positive? ? " (Unrecognised #{pame_unrec})" : ''}" }
+            { type: 'mrkdwn',
+              text: "*Green List*\n#{gl_imported || 0} (Not found #{gl_not_found}, Invalid #{gl_invalid}#{gl_duplicates.positive? ? ", Duplicates #{gl_duplicates}" : ''})" },
+            { type: 'mrkdwn',
+              text: "*PAME*\n#{pame_imported || 0}#{pame_unrec.positive? ? " (Unrecognised #{pame_unrec})" : ''}" }
           ]
         }
       ]
 
-      post_json(text: "Import core completed", blocks: blocks)
+      post_json(text: 'Import core completed', blocks: blocks)
     end
 
     private
@@ -212,13 +234,8 @@ module PortalRelease
     # Safe dig that accepts symbol or string keys at each level
     def value(h, *keys)
       keys.reduce(h) do |acc, key|
-        if acc.is_a?(Hash)
-          acc[key] || acc[key.to_s]
-        else
-          nil
-        end
+        acc[key] || acc[key.to_s] if acc.is_a?(Hash)
       end
     end
   end
 end
-

--- a/app/services/portal_release/notifier.rb
+++ b/app/services/portal_release/notifier.rb
@@ -65,11 +65,24 @@ module PortalRelease
 
     # Rollback notifications
     def rollback_ok(timestamp)
-      post(":rewind: Rollback to backup #{timestamp} succeeded")
+      post(":rewind: Rollback to backup #{timestamp} succeeded. Now cleaning up...")
     end
 
     def rollback_failed(e, timestamp)
       post(":rotating_light: Rollback to backup #{timestamp} failed: #{e.message}")
+    end
+
+    def rollback_cleanup_failed(e, timestamp)
+      post(":warning: Rollback to backup #{timestamp} succeeded, but cleanup failed: #{e.message}")
+    end
+
+    def rollback_cleanup_okay(timestamp)
+      post(":white_check_mark: cleanup has been done. Rollabck to #{timestamp} is now complete. The website is now using rollback data.")
+    end
+
+    def rollback_step_started(step, timestamp)
+      step_name = step.humanize.gsub('_', ' ')
+      post(":hourglass_flowing_sand: Rollback step '#{step_name}' started (backup #{timestamp})")
     end
 
     private

--- a/app/services/portal_release/notifier.rb
+++ b/app/services/portal_release/notifier.rb
@@ -184,6 +184,8 @@ module PortalRelease
         ['refresh_views', 'Refresh portal materialized views']
       when 'preflight'
         ['preflight', 'Checks: views exist, counts, geometry, duplicates']
+      when 'create_portal_downloads_view'
+        ['create_portal_downloads_view', 'Delete and recreate combined file generator downloads view']
       when 'build_staging'
         ['build_staging', 'Create/prepare staging tables']
       when 'import_core'

--- a/app/services/portal_release/preflight.rb
+++ b/app/services/portal_release/preflight.rb
@@ -4,7 +4,9 @@ module PortalRelease
   class Preflight
     class << self
       def refresh_mvs!(log)
-        return unless ActiveModel::Type::Boolean.new.cast(ENV['PP_RELEASE_REFRESH_VIEWS'])
+        # Default to true if PP_RELEASE_REFRESH_VIEWS is not set
+        refresh_views = ENV['PP_RELEASE_REFRESH_VIEWS']
+        return unless ActiveModel::Type::Boolean.new.cast(refresh_views.nil? ? 'true' : refresh_views)
 
         Wdpa::Portal::Managers::ViewManager.refresh_materialized_views
         log.event('mvs_refreshed')

--- a/app/services/portal_release/preflight.rb
+++ b/app/services/portal_release/preflight.rb
@@ -82,7 +82,9 @@ module PortalRelease
         downloads_view = Wdpa::Portal::Config::PortalImportConfig::PORTAL_VIEWS['downloads']
 
         conn.transaction do
-          # Drop the view first to avoid column name conflicts with CREATE OR REPLACE
+          # Drop all temporary download views that depends on the downloads view
+          Download::Generators::Base.clean_tmp_download_views
+
           conn.execute("DROP VIEW IF EXISTS #{downloads_view}")
           as_query = Download::Queries.build_query_for_downloads_view(true)
 

--- a/app/services/portal_release/service.rb
+++ b/app/services/portal_release/service.rb
@@ -48,6 +48,7 @@ module PortalRelease
       @ctx   = {}
 
       begin
+        validate_label_format!(@label)
         @release = Release.create!(label: label)
         @log     = ::PortalRelease::Logger.new(@release)
         @notify  = ::PortalRelease::Notifier.new(@release)
@@ -94,6 +95,15 @@ module PortalRelease
     end
 
     private
+
+    # Only "MMMYYYY" is allowed
+    LABEL_REGEX = /\A[A-Z][a-z]{2}\d{4}\z/.freeze
+
+    def validate_label_format!(label)
+      return if LABEL_REGEX.match?(label.to_s)
+
+      raise ArgumentError, "Invalid release label '#{label}'. Expected format MMMYYYY (e.g., Sep2025)."
+    end
 
     # Yields to the phase block and returns duration in seconds
     def time

--- a/app/services/portal_release/service.rb
+++ b/app/services/portal_release/service.rb
@@ -5,8 +5,8 @@ module PortalRelease
     PHASES = %i[
       acquire_lock
       refresh_views
-      preflight
       create_portal_downloads_view
+      preflight
       build_staging
       import_core
       import_related
@@ -131,7 +131,7 @@ module PortalRelease
 
     def import_core
       @ctx[:phase] = 'import_core'
-      results = Importer.new(@log, label: @label).run_core!
+      results = Importer.new(@log, label: @label, notifier: @notify).run_core!
       @release.update!(state: 'importing', stats_json: (@release.stats_json || {}).merge({ importer: results }))
       # Human-readable Slack summary for core import
       @notify.import_core_summary(results) if results.respond_to?(:each)

--- a/app/services/portal_release/service.rb
+++ b/app/services/portal_release/service.rb
@@ -6,6 +6,7 @@ module PortalRelease
       acquire_lock
       refresh_views
       preflight
+      create_portal_downloads_view
       build_staging
       import_core
       import_related
@@ -110,6 +111,11 @@ module PortalRelease
       Preflight.run!(@release, @log, @notify, @ctx)
     end
 
+    def create_portal_downloads_view
+      @ctx[:phase] = 'create_portal_downloads_view'
+      Preflight.create_portal_downloads_view!(@log)
+    end
+
     def build_staging
       @ctx[:phase] = 'build_staging'
       Staging.new(@log).prepare!
@@ -157,4 +163,3 @@ module PortalRelease
     end
   end
 end
-

--- a/app/services/portal_release/service.rb
+++ b/app/services/portal_release/service.rb
@@ -103,7 +103,7 @@ module PortalRelease
     def validate_label_format!(label)
       return if LABEL_REGEX.match?(label.to_s)
 
-      raise ArgumentError, "Invalid release label '#{label}'. Expected format MMMYYYY (e.g., Sep2025)."
+      raise ArgumentError, "Invalid release label '#{label}'. Expected format MMMYYYY with English month abbreviation (e.g., Jan2025, Feb2025)."
     end
 
     # Yields to the phase block and returns duration in seconds

--- a/app/services/portal_release/service.rb
+++ b/app/services/portal_release/service.rb
@@ -24,9 +24,8 @@ module PortalRelease
       true
     end
 
-    def self.rollback_last!
-      # Allow rollback to post Slack notifications even without a Release context
-      SwapManager.new.rollback!
+    def self.rollback_to!(timestamp)
+      SwapManager.new.rollback_to!(timestamp)
     end
 
     def self.status_report

--- a/app/services/portal_release/validate.rb
+++ b/app/services/portal_release/validate.rb
@@ -32,9 +32,9 @@ module PortalRelease
 
     def source_counts
       {
-        points: c("SELECT COUNT(*) FROM #{Wdpa::Portal::Config::PortalImportConfig::PORTAL_VIEWS['points']}"),
-        polygons: c("SELECT COUNT(*) FROM #{Wdpa::Portal::Config::PortalImportConfig::PORTAL_VIEWS['polygons']}"),
-        sources: c("SELECT COUNT(*) FROM #{Wdpa::Portal::Config::PortalImportConfig::PORTAL_VIEWS['sources']}")
+        points: c("SELECT COUNT(*) FROM #{Wdpa::Portal::Config::PortalImportConfig::PORTAL_MATERIALISED_VIEWS['points']}"),
+        polygons: c("SELECT COUNT(*) FROM #{Wdpa::Portal::Config::PortalImportConfig::PORTAL_MATERIALISED_VIEWS['polygons']}"),
+        sources: c("SELECT COUNT(*) FROM #{Wdpa::Portal::Config::PortalImportConfig::PORTAL_MATERIALISED_VIEWS['sources']}")
       }
     end
 

--- a/app/services/portal_release/validate.rb
+++ b/app/services/portal_release/validate.rb
@@ -32,9 +32,9 @@ module PortalRelease
 
     def source_counts
       {
-        points: c('SELECT COUNT(*) FROM portal_standard_points'),
-        polygons: c('SELECT COUNT(*) FROM portal_standard_polygons'),
-        sources: c('SELECT COUNT(*) FROM portal_standard_sources')
+        points: c("SELECT COUNT(*) FROM #{Wdpa::Portal::Config::PortalImportConfig::PORTAL_VIEWS['points']}"),
+        polygons: c("SELECT COUNT(*) FROM #{Wdpa::Portal::Config::PortalImportConfig::PORTAL_VIEWS['polygons']}"),
+        sources: c("SELECT COUNT(*) FROM #{Wdpa::Portal::Config::PortalImportConfig::PORTAL_VIEWS['sources']}")
       }
     end
 
@@ -53,4 +53,3 @@ module PortalRelease
     end
   end
 end
-

--- a/app/workers/download_workers/base.rb
+++ b/app/workers/download_workers/base.rb
@@ -1,37 +1,46 @@
 class DownloadWorkers::Base
   include Sidekiq::Worker
-  sidekiq_options :retry => false, :backtrace => true
+  sidekiq_options retry: false, backtrace: true
 
   def self.perform_async *args
     queue = if args.last.is_a?(Hash) && args.last[:for_import]
-      args.pop unless keep_last_arg args
-      'import'
-    else
-      'default'
-    end
+              args.pop unless keep_last_arg args
+              'import'
+            else
+              'default'
+            end
 
     Sidekiq::Client.push('class' => self, 'queue' => queue, 'args' => args)
   end
 
   protected
 
-  def key identifier, format
+  def key(identifier, format)
     Download::Utils.key domain, identifier, format
   end
 
-  def filename identifier, format
+  def filename(identifier, format)
     Download::Utils.filename domain, identifier, format
   end
 
-  def while_generating key
+  def while_generating(key)
     properties = Download::Utils.properties(key)
-    generating_properties = properties.merge({'status' => 'generating'})
-
+    generating_properties = properties.merge({ 'status' => 'generating' })
     $redis.set(key, generating_properties.to_json)
-    $redis.set(key, yield)
+
+    begin
+      result_json = yield
+      $redis.set(key, result_json)
+    rescue StandardError => e
+      failed_properties = properties.merge({ 'status' => 'failed', 'error' => e.message })
+      $redis.set(key, failed_properties.to_json)
+      Rails.logger.error("Download generation failed for #{key}: #{e.message}")
+      # Do not re-raise so status remains failed and future requests can re-enqueue
+      failed_properties.to_json
+    end
   end
 
-  def self.keep_last_arg args
-    self.instance_method(:perform).arity.abs == args.size
+  def self.keep_last_arg(args)
+    instance_method(:perform).arity.abs == args.size
   end
 end

--- a/app/workers/download_workers/general.rb
+++ b/app/workers/download_workers/general.rb
@@ -1,10 +1,10 @@
 class DownloadWorkers::General < DownloadWorkers::Base
-  def perform format, type, identifier, opts={}
+  def perform(format, type, identifier, opts = {})
     while_generating(key(identifier, format)) do
-      _opts = opts.symbolize_keys.merge({wdpa_ids: collect_wdpa_ids(type, identifier)})
+      options = opts.symbolize_keys.merge({ site_ids: collect_site_ids(type, identifier) })
 
-      Download.generate format, filename(identifier, format), _opts
-      {status: 'ready', filename: filename(identifier, format)}.to_json
+      Download.generate format, filename(identifier, format), options
+      { status: 'ready', filename: filename(identifier, format) }.to_json
     end
   end
 
@@ -14,17 +14,17 @@ class DownloadWorkers::General < DownloadWorkers::Base
     'general'
   end
 
-  def collect_wdpa_ids type, identifier=nil
-    wdpa_ids_per_country = -> (country) {country.protected_areas.pluck(:wdpa_id)}
+  def collect_site_ids(type, identifier = nil)
+    site_ids_per_country = ->(country) { country.protected_areas.pluck(:wdpa_id) }
 
     case type
     when 'general'
       nil
     when 'country'
-      wdpa_ids_per_country.call(Country.where(iso_3: identifier).first)
+      site_ids_per_country.call(Country.where(iso_3: identifier).first)
     when 'region'
       region = Region.where(iso: identifier).first
-      Set.new(region.countries.flat_map(&wdpa_ids_per_country)).to_a
+      Set.new(region.countries.flat_map(&site_ids_per_country)).to_a
     when 'marine'
       ProtectedArea.marine_areas.pluck(:wdpa_id)
     when 'greenlist'

--- a/app/workers/download_workers/protected_area.rb
+++ b/app/workers/download_workers/protected_area.rb
@@ -1,8 +1,8 @@
 class DownloadWorkers::ProtectedArea < DownloadWorkers::Base
-  def perform format, wdpa_id, opts={}
-    while_generating(key(wdpa_id, format)) do
-      Download.generate format, filename(wdpa_id, format), opts.symbolize_keys.merge({wdpa_ids: [wdpa_id]})
-      {status: 'ready', filename: filename(wdpa_id, format)}.to_json
+  def perform(format, site_id, opts = {})
+    while_generating(key(site_id, format)) do
+      Download.generate format, filename(site_id, format), opts.symbolize_keys.merge({ site_ids: [site_id] })
+      { status: 'ready', filename: filename(site_id, format) }.to_json
     end
   end
 
@@ -12,4 +12,3 @@ class DownloadWorkers::ProtectedArea < DownloadWorkers::Base
     'protected_area'
   end
 end
-

--- a/app/workers/download_workers/search.rb
+++ b/app/workers/download_workers/search.rb
@@ -1,5 +1,5 @@
 class DownloadWorkers::Search < DownloadWorkers::Base
-  def perform format, token, search_term, filters
+  def perform(format, token, search_term, filters)
     @format = format
     @token = token
     @search_term = search_term
@@ -8,7 +8,7 @@ class DownloadWorkers::Search < DownloadWorkers::Base
 
     while_generating(key(token, format)) do
       generate_download
-      {status: 'ready', filename: filename(ids_digest, format)}.to_json
+      { status: 'ready', filename: filename(ids_digest, format) }.to_json
     end
   end
 
@@ -19,17 +19,18 @@ class DownloadWorkers::Search < DownloadWorkers::Base
   end
 
   def generate_download
-    Download.generate(@format, filename(ids_digest, @format), {wdpa_ids: protected_area_ids})
+    Download.generate(@format, filename(ids_digest, @format), { site_ids: protected_area_site_ids })
   end
 
   def ids_digest
     return "#{@token}" if @search_term.blank?
     return "#{@search_term}_#{@token}".gsub(' ', '_') if @filters_values.empty?
+
     filter = @filters_values.map { |f| f.to_s[0..9] }.join(',')
     "#{@search_term[0..11]}_#{filter}_#{@token}".gsub(' ', '_')
   end
 
-  def protected_area_ids
+  def protected_area_site_ids
     search.all_wdpa_ids
   end
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ services:
       - "3000:3000"
     networks:
       - protectedplanet
+    env_file:
+      - '.env'
     environment:
       - SSH_AUTH_SOCK=/ssh-agent
       - WEBPACKER_DEV_SERVER_HOST=webpacker
@@ -61,6 +63,8 @@ services:
       - protectedplanet_bundler:/usr/local/bundle
     networks:
       - protectedplanet
+    env_file:
+      - '.env'
     depends_on:
       - db
       - redis
@@ -110,6 +114,8 @@ services:
       - protectedplanet_bundler:/usr/local/bundle
     ports:
       - "3035:3035"
+    env_file:
+      - '.env'
     networks:
       - protectedplanet
   sidekiq-import:
@@ -122,6 +128,8 @@ services:
       - protectedplanet_bundler:/usr/local/bundle
     networks:
       - protectedplanet
+    env_file:
+      - '.env'
     depends_on:
       - db
       - redis

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -26,7 +26,7 @@ array of WDPA IDs. It is the responsibility of the caller to decide what
 is to be downloaded, and what the file should be saved as in S3.
 
 ```
-Download.generate 'download_name', wdpa_ids: [123, 456, 2881]
+Download.generate 'download_name', site_ids: [123, 456, 2881]
 ```
 
 ### Data

--- a/docs/portal_release_runbook.md
+++ b/docs/portal_release_runbook.md
@@ -166,7 +166,7 @@ Release flow control (app/services/portal_release/service.rb):
 - PP_RELEASE_STOP_AFTER — phase name to stop after
 - PP_RELEASE_ONLY_PHASES — comma‑separated list of phases to run
 - PP_RELEASE_DRY_RUN — true/false; if true, skip atomic swap and post‑swap VACUUM of live tables
-- PP_RELEASE_REFRESH_VIEWS — true/false; refresh portal MVs in the refresh_views phase
+- PP_RELEASE_REFRESH_VIEWS — true/false; refresh portal MVs in the refresh_views phase (defaults to true)
 
 Swap/rollback (app/services/portal_release/swap_manager.rb):
 - PP_RELEASE_ROLLBACK_TO — timestamp YYMMDDHHMM to rollback to (e.g. 2509121644)

--- a/docs/portal_release_runbook.md
+++ b/docs/portal_release_runbook.md
@@ -56,7 +56,7 @@ docker compose exec -T web bash -lc \
   'PP_RELEASE_DRY_RUN=true \
    PP_RELEASE_STAGING_LIGHTWEIGHT=true \
    PP_RELEASE_REFRESH_VIEWS=false \
-   bundle exec rake pp:portal:release["WDPA_2025_09_DRYRUN"]'
+   bundle exec rake pp:portal:release["Sep2025_DRYRUN"]'
 ```
 
 Real swap (production-like):
@@ -66,7 +66,7 @@ docker compose exec -T web bash -lc \
   'PP_RELEASE_DRY_RUN=false \
    PP_RELEASE_STAGING_LIGHTWEIGHT=false \
    PP_RELEASE_REFRESH_VIEWS=true \
-   bundle exec rake pp:portal:release["WDPA_2025_09"]'
+   bundle exec rake pp:portal:release["Sep2025"]'
 ```
 
 Resume a release from a specific phase (e.g. import_core):
@@ -74,7 +74,7 @@ Resume a release from a specific phase (e.g. import_core):
 ```bash
 docker compose exec -T web bash -lc \
   'PP_RELEASE_START_AT=import_core \
-   bundle exec rake pp:portal:release["WDPA_2025_09"]'
+   bundle exec rake pp:portal:release["Sep2025"]'
 ```
 
 Run only certain phases:
@@ -82,7 +82,7 @@ Run only certain phases:
 ```bash
 docker compose exec -T web bash -lc \
   'PP_RELEASE_ONLY_PHASES=refresh_views,preflight \
-   bundle exec rake pp:portal:release["WDPA_2025_09_CHECK"]'
+   bundle exec rake pp:portal:release["Sep2025_CHECK"]'
 ```
 
 Status, abort & rollback helpers:

--- a/docs/portal_release_runbook.md
+++ b/docs/portal_release_runbook.md
@@ -181,6 +181,7 @@ Importer (app/services/portal_release/importer.rb and dev tasks):
 - PP_IMPORT_SKIP — comma list of importers to skip
 - PP_IMPORT_SAMPLE — integer to limit batch sizes for sampling
 - PP_IMPORT_CHECKPOINTS_DISABLE — set to 'false' to enable checkpoint resume mode via dev tasks
+- PP_IMPORT_PROGRESS_NOTIFICATIONS — set to 'false' to silence per-import progress notifications (defaults to true)
 
 Logging & Slack (app/services/portal_release/*.rb):
 - PP_SLACK_WEBHOOK_URL — Slack Incoming Webhook for release notifications (start/phase complete/swap/fail/rollback)
@@ -225,6 +226,8 @@ docker compose exec -T web bash -lc 'tail -n 100 -f log/portal_release.log'
 export PP_SLACK_WEBHOOK_URL={{PP_SLACK_WEBHOOK_URL}}
 # Optional: reduce noise by disabling per‑phase posts
 export PP_RELEASE_SLACK_PHASE_COMPLETE=false
+# Optional: silence importer progress notifications (defaults to true)
+export PP_IMPORT_PROGRESS_NOTIFICATIONS=false
 ```
 
 3) Run a dry run and watch for start/phase/finish messages in Slack and the log file:

--- a/docs/step3_release_orchestration.md
+++ b/docs/step3_release_orchestration.md
@@ -50,7 +50,7 @@ rake pp:portal:rollback
 
 ## Configuration
 
-- `PP_RELEASE_REFRESH_VIEWS=true` to refresh Portal materialized views in preflight
+- `PP_RELEASE_REFRESH_VIEWS=true` to refresh Portal materialized views in preflight (defaults to true)
 - `PP_SLACK_WEBHOOK_URL` to enable Slack notifications (optional)
 
 ## Next (Step 4)

--- a/lib/modules/download.rb
+++ b/lib/modules/download.rb
@@ -1,17 +1,17 @@
 module Download
-  def self.request params
+  def self.request(params)
     Download::Router.request(params.delete('domain'), params)
   end
 
-  def self.poll params
+  def self.poll(params)
     Download::Poller.poll(params)
   end
 
-  def self.link_to filename
+  def self.link_to(filename)
     Download::Utils.link_to filename
   end
 
-  def self.set_email params
+  def self.set_email(params)
     Download::Router.set_email(params.delete('domain'), params)
   end
 
@@ -19,16 +19,16 @@ module Download
     Utils.clear_downloads
   end
 
-  def self.generation_info domain, identifier, format
+  def self.generation_info(domain, identifier, format)
     Download::Utils.properties(Download::Utils.key(domain, identifier, format))
   end
 
-  def self.has_failed? domain, identifier, format
+  def self.has_failed?(domain, identifier, format)
     status = generation_info(domain, identifier, format)['status']
-    status.present? && !%w(generating ready).include?(status)
+    status.present? && !%w[generating ready].include?(status)
   end
 
-  def self.is_ready? domain, identifier, format
+  def self.is_ready?(domain, identifier, format)
     generation_info(domain, identifier, format)['status'] == 'ready'
   end
 
@@ -43,26 +43,27 @@ module Download
     pdf: Download::Generators::Pdf
   }.freeze
 
-  def self.generate format, download_name, opts={}
-
+  def self.generate(format, download_name, opts = {})
     generator = GENERATORS[format.to_sym]
     zip_path = Utils.zip_path(download_name)
 
-    generated = generator.generate zip_path, opts[option(format)]
+    generated = generator.generate zip_path, option(format, opts)
 
-    if generated
-      upload_to_s3 zip_path, opts[:for_import]
-      clean_up zip_path
+    return unless generated
+
+    upload_to_s3 zip_path, opts[:for_import]
+    clean_up zip_path
+  end
+
+  def self.option(format, opts)
+    if format.to_s == 'pdf'
+      opts[:identifier]
+    else
+      opts[:site_ids]
     end
   end
 
-  private
-
-  def self.option(format)
-    format.to_s == 'pdf' ? :identifier : :wdpa_ids
-  end
-
-  def self.upload_to_s3 zip_path, for_import
+  def self.upload_to_s3(zip_path, for_import)
     download_name = File.basename(zip_path)
     prefix = for_import ? IMPORT_PREFIX : CURRENT_PREFIX
     prefixed_download_name = prefix + download_name
@@ -70,7 +71,7 @@ module Download
     S3.upload prefixed_download_name, zip_path
   end
 
-  def self.clean_up path
+  def self.clean_up(path)
     FileUtils.rm_rf path
   end
 end

--- a/lib/modules/download/generators/base.rb
+++ b/lib/modules/download/generators/base.rb
@@ -77,13 +77,13 @@ class Download::Generators::Base
 
   def query(conditions = [])
     query = %(SELECT "TYPE", #{Download::Utils.download_columns})
-    query << " FROM #{Wdpa::Release::DOWNLOADS_VIEW_NAME}"
+    query << " FROM #{Wdpa::Portal::Config::PortalImportConfig::PORTAL_VIEWS['downloads']}"
     add_conditions(query, conditions).squish
   end
 
   def add_conditions(query, conditions)
     conditions = Array.wrap(conditions)
-    conditions << %{"WDPAID" IN (#{@wdpa_ids.join(',')})} if @wdpa_ids.present?
+    conditions << %{"SITE_ID" IN (#{@wdpa_ids.join(',')})} if @wdpa_ids.present?
 
     query.tap do |q|
       q << " WHERE #{conditions.join(' AND ')}" if conditions.any?

--- a/lib/modules/download/generators/gdb.rb
+++ b/lib/modules/download/generators/gdb.rb
@@ -62,7 +62,7 @@ class Download::Generators::Gdb < Download::Generators::Base
   def export_sources
     _query = <<-SQL
       SELECT #{Download::Utils.source_columns}
-      FROM standard_sources
+      FROM #{Wdpa::Portal::Config::PortalImportConfig::PORTAL_VIEWS['sources']}
     SQL
 
     Ogr::Postgres.export(:gdb, gdb_component, _query, 'source')

--- a/lib/modules/download/generators/gdb.rb
+++ b/lib/modules/download/generators/gdb.rb
@@ -10,14 +10,14 @@ class Download::Generators::Gdb < Download::Generators::Base
     }
   }.freeze
 
-  def initialize(zip_path, wdpa_ids)
+  def initialize(zip_path, site_ids)
+    super(zip_path, site_ids)
     @path = File.dirname(zip_path)
     @filename = File.basename(zip_path, File.extname(zip_path))
-    @wdpa_ids = wdpa_ids
   end
 
   def generate
-    return false if @wdpa_ids.is_a?(Array) && @wdpa_ids.empty?
+    return false if @site_ids.is_a?(Array) && @site_ids.empty?
 
     clean_up_after do
       QUERY_CONDITIONS.each do |name, props|
@@ -61,12 +61,12 @@ class Download::Generators::Gdb < Download::Generators::Base
   end
 
   def export_sources
-    _query = <<-SQL
+    query = <<-SQL
       SELECT #{Download::Utils.source_columns}
-      FROM #{Wdpa::Portal::Config::PortalImportConfig::PORTAL_VIEWS['sources']}
+      FROM #{Wdpa::Portal::Config::PortalImportConfig::PORTAL_MATERIALISED_VIEWS['sources']}
     SQL
 
-    Ogr::Postgres.export(:gdb, gdb_component, _query, 'source')
+    Ogr::Postgres.export(:gdb, gdb_component, query, 'source')
   end
 
   def clean_up_after

--- a/lib/modules/download/generators/shapefile.rb
+++ b/lib/modules/download/generators/shapefile.rb
@@ -93,9 +93,9 @@ class Download::Generators::Shapefile < Download::Generators::Base
     end
   end
 
-  def zip_path(index='')
-    _filename = index.present? ? "#{@filename}_#{index}" : @filename
-    File.join(@path, "#{_filename}.zip")
+  def zip_path(index = '')
+    base_filename = index.present? ? "#{@filename}_#{index}" : @filename
+    File.join(@path, "#{base_filename}.zip")
   end
 
   def shapefile_components name

--- a/lib/modules/download/generators/shapefile.rb
+++ b/lib/modules/download/generators/shapefile.rb
@@ -1,24 +1,24 @@
 class Download::Generators::Shapefile < Download::Generators::Base
   TYPE = 'shapefile'.freeze
-  SHAPEFILE_PARTS = ['shp', 'shx',  'dbf', 'prj', 'cpg']
+  SHAPEFILE_PARTS = %w[shp shx dbf prj cpg]
 
   QUERY_CONDITIONS = {
     polygons: {
       select: Download::Utils.download_columns,
-      where: %{"TYPE" = 'Polygon'}
+      where: %("TYPE" = 'Polygon')
     },
-    points:   {
-      select: Download::Utils.download_columns(reject: [:gis_area, :gis_m_area]),
-      where: %{"TYPE" = 'Point'}
+    points: {
+      select: Download::Utils.download_columns(reject: %i[gis_area gis_m_area]),
+      where: %("TYPE" = 'Point')
     }
   }.freeze
 
-  def initialize zip_path, wdpa_ids, number_of_pieces=3
+  def initialize(zip_path, wdpa_ids, number_of_pieces = 3)
     @path = File.dirname(zip_path)
     @filename = File.basename(zip_path, File.extname(zip_path))
     @wdpa_ids = wdpa_ids
     # If there are 2 areas involved max, generate just one shp
-    @number_of_pieces = (wdpa_ids.size > 2 || wdpa_ids.blank?) ? number_of_pieces : 1
+    @number_of_pieces = wdpa_ids.size > 2 || wdpa_ids.blank? ? number_of_pieces : 1
   end
 
   def generate
@@ -39,30 +39,30 @@ class Download::Generators::Shapefile < Download::Generators::Base
     end
     merge_files
   rescue Ogr::Postgres::ExportError
-    return false
+    false
   end
 
   private
 
-  def export_component name, props, piece_index
+  def export_component(name, props, piece_index)
     component_paths = shapefile_components(name)
     view_name = create_view query(props[:select], props[:where])
 
-    total_count = ActiveRecord::Base.connection.select_value("""
+    total_count = ActiveRecord::Base.connection.select_value("
       SELECT COUNT(*) FROM #{view_name}
-    """).to_i
+    ").to_i
 
     return [] if total_count.zero?
 
     limit = (total_count / @number_of_pieces.to_f).ceil
     offset = limit * piece_index
-    order_by = 'ORDER BY \""WDPAID"\" ASC'
-    sql = """
+    order_by = 'ORDER BY \""SITE_ID"\" ASC'
+    sql = "
       SELECT *
       FROM #{view_name}
       #{order_by if name.to_s == 'polygons'}
       LIMIT #{limit} OFFSET #{offset}
-    """.squish
+    ".squish
 
     export_success = Ogr::Postgres.export(
       :shapefile,
@@ -71,12 +71,13 @@ class Download::Generators::Shapefile < Download::Generators::Base
     )
 
     raise Ogr::Postgres::ExportError unless export_success
+
     component_paths
   end
 
-  def query select, conditions=[]
+  def query(select, conditions = [])
     query = "SELECT #{select}"
-    query << " FROM #{Wdpa::Release::DOWNLOADS_VIEW_NAME}"
+    query << " FROM #{Wdpa::Portal::Config::PortalImportConfig::PORTAL_VIEWS['downloads']}"
     add_conditions(query, conditions).squish
   end
 
@@ -98,22 +99,21 @@ class Download::Generators::Shapefile < Download::Generators::Base
     File.join(@path, "#{base_filename}.zip")
   end
 
-  def shapefile_components name
+  def shapefile_components(name)
     SHAPEFILE_PARTS.collect do |ext|
       File.join(@path, "#{@filename}-#{name}.#{ext}")
     end
   end
 
   def merge_files
-    range = (0..@number_of_pieces-1)
+    range = (0..@number_of_pieces - 1)
     files_paths = range.map { |i| zip_path(i) }.join(' ')
 
     system("zip -j #{zip_path} #{files_paths}") and
-    add_sources and
-    add_attachments and
-    add_shapefile_readme
+      add_sources and
+      add_attachments and
+      add_shapefile_readme
 
     range.each { |i| FileUtils.rm_rf(zip_path(i)) }
   end
-
 end

--- a/lib/modules/download/generators/shapefile.rb
+++ b/lib/modules/download/generators/shapefile.rb
@@ -13,16 +13,16 @@ class Download::Generators::Shapefile < Download::Generators::Base
     }
   }.freeze
 
-  def initialize(zip_path, wdpa_ids, number_of_pieces = 3)
+  def initialize(zip_path, site_ids, number_of_pieces = 3)
+    super(zip_path, site_ids)
     @path = File.dirname(zip_path)
     @filename = File.basename(zip_path, File.extname(zip_path))
-    @wdpa_ids = wdpa_ids
     # If there are 2 areas involved max, generate just one shp
-    @number_of_pieces = wdpa_ids.size > 2 || wdpa_ids.blank? ? number_of_pieces : 1
+    @number_of_pieces = site_ids.size > 2 || site_ids.blank? ? number_of_pieces : 1
   end
 
   def generate
-    return false if @wdpa_ids.is_a?(Array) && @wdpa_ids.empty?
+    return false if @site_ids.is_a?(Array) && @site_ids.empty?
 
     shapefile_paths = []
 

--- a/lib/modules/download/queries.rb
+++ b/lib/modules/download/queries.rb
@@ -4,7 +4,7 @@ module Download
       wkb_geometry
       site_id site_pid
       site_type name_eng name
-      desig_eng desig_type
+      desig desig_eng desig_type
       iucn_cat int_crit
       realm
       rep_m_area rep_area
@@ -53,7 +53,7 @@ module Download
       { select: "#{aliased_columns}", from: polygons_view }
     end
 
-    def self.mixed(with_type)
+    def self.build_query_for_downloads_view(with_type)
       add_type = ->(type) { %('#{type}' AS "TYPE", ) if with_type }
       points = for_points({ 13 => %(NULL AS "GIS_M_AREA"), 15 => %(NULL AS "GIS_AREA") })
 

--- a/lib/modules/download/queries.rb
+++ b/lib/modules/download/queries.rb
@@ -1,16 +1,23 @@
 module Download
   module Queries
     POINTS_COLUMNS = %i[
-      wkb_geometry wdpaid wdpa_pid
-      pa_def name orig_name
-      desig desig_eng desig_type
-      iucn_cat int_crit marine
-      rep_m_area rep_area no_take
-      no_tk_area status status_yr
-      gov_type own_type mang_auth
-      mang_plan verif metadataid
-      sub_loc parent_iso3 iso3
+      wkb_geometry
+      site_id site_pid
+      site_type name_eng name
+      desig_eng desig_type
+      iucn_cat int_crit
+      realm
+      rep_m_area rep_area
+      no_take no_tk_area
+      status status_yr
+      gov_type govsubtype
+      own_type ownsubtype
+      mang_auth mang_plan
+      verif metadataid
+      prnt_iso3 iso3
       supp_info cons_obj
+      inlnd_wtrs
+      oecm_asmt
     ]
 
     POLYGONS_COLUMNS = POINTS_COLUMNS.clone

--- a/lib/modules/download/queries.rb
+++ b/lib/modules/download/queries.rb
@@ -40,7 +40,7 @@ module Download
         aliased_columns.insert(position, name)
       end
 
-      points_view = Wdpa::Portal::Config::PortalImportConfig::PORTAL_VIEWS['points']
+      points_view = Wdpa::Portal::Config::PortalImportConfig::PORTAL_MATERIALISED_VIEWS['points']
       { select: "#{aliased_columns.join(',')}", from: points_view }
     end
 
@@ -49,7 +49,7 @@ module Download
         %(#{column} AS "#{column.upcase}")
       end.join(',')
 
-      polygons_view = Wdpa::Portal::Config::PortalImportConfig::PORTAL_VIEWS['polygons']
+      polygons_view = Wdpa::Portal::Config::PortalImportConfig::PORTAL_MATERIALISED_VIEWS['polygons']
       { select: "#{aliased_columns}", from: polygons_view }
     end
 

--- a/lib/modules/download/queries.rb
+++ b/lib/modules/download/queries.rb
@@ -1,63 +1,65 @@
 module Download
   module Queries
-    POINTS_COLUMNS = [
-      :wkb_geometry, :wdpaid, :wdpa_pid,
-      :pa_def, :name, :orig_name,
-      :desig, :desig_eng, :desig_type,
-      :iucn_cat, :int_crit, :marine,
-      :rep_m_area, :rep_area, :no_take,
-      :no_tk_area, :status, :status_yr,
-      :gov_type, :own_type, :mang_auth,
-      :mang_plan, :verif, :metadataid,
-      :sub_loc, :parent_iso3, :iso3,
-      :supp_info, :cons_obj
+    POINTS_COLUMNS = %i[
+      wkb_geometry wdpaid wdpa_pid
+      pa_def name orig_name
+      desig desig_eng desig_type
+      iucn_cat int_crit marine
+      rep_m_area rep_area no_take
+      no_tk_area status status_yr
+      gov_type own_type mang_auth
+      mang_plan verif metadataid
+      sub_loc parent_iso3 iso3
+      supp_info cons_obj
     ]
 
     POLYGONS_COLUMNS = POINTS_COLUMNS.clone
       .insert(13, :gis_m_area).insert(15, :gis_area)
 
-    SOURCE_COLUMNS = [
-      :metadataid, :data_title, :resp_party,
-      :year, :update_yr, :char_set,
-      :ref_system, :scale, :lineage,
-      :citation, :disclaimer, :language,
-      :verifier
+    SOURCE_COLUMNS = %i[
+      metadataid data_title resp_party
+      year update_yr char_set
+      ref_system scale lineage
+      citation disclaimer language
+      verifier
     ]
 
-    def self.for_points extra_columns={}
-      aliased_columns = POINTS_COLUMNS.map { |column|
-        %{#{column} AS "#{column.upcase}"}
-      }
+    def self.for_points(extra_columns = {})
+      aliased_columns = POINTS_COLUMNS.map do |column|
+        %(#{column} AS "#{column.upcase}")
+      end
 
-      extra_columns.each { |(position, name)|
+      extra_columns.each do |(position, name)|
         aliased_columns.insert(position, name)
-      }
+      end
 
-      {select: "#{aliased_columns.join(',')}", from: 'standard_points'}
+      points_view = Wdpa::Portal::Config::PortalImportConfig::PORTAL_VIEWS['points']
+      { select: "#{aliased_columns.join(',')}", from: points_view }
     end
 
     def self.for_polygons
-      aliased_columns = POLYGONS_COLUMNS.map { |column|
-        %{#{column} AS "#{column.upcase}"}
-      }.join(',')
+      aliased_columns = POLYGONS_COLUMNS.map do |column|
+        %(#{column} AS "#{column.upcase}")
+      end.join(',')
 
-      {select: "#{aliased_columns}", from: 'standard_polygons'}
+      polygons_view = Wdpa::Portal::Config::PortalImportConfig::PORTAL_VIEWS['polygons']
+      { select: "#{aliased_columns}", from: polygons_view }
     end
 
-    def self.mixed with_type
-      add_type = -> type { %{'#{type}' AS "TYPE", } if with_type }
-      points = for_points({13 => %{NULL AS "GIS_M_AREA"}, 15 => %{NULL AS "GIS_AREA"}})
+    def self.mixed(with_type)
+      add_type = ->(type) { %('#{type}' AS "TYPE", ) if with_type }
+      points = for_points({ 13 => %(NULL AS "GIS_M_AREA"), 15 => %(NULL AS "GIS_AREA") })
 
       selected_columns = with_type ? '*' : for_polygons[:select]
-      from = """
+      from = "
         (SELECT #{add_type['Polygon']} #{for_polygons[:select]}
         FROM #{for_polygons[:from]}
         UNION ALL
         SELECT #{add_type['Point']} #{points[:select]}
         FROM #{points[:from]}) AS all_pas
-      """.squish
+      ".squish
 
-      {select: selected_columns, from: from}
+      { select: selected_columns, from: from }
     end
   end
 end

--- a/lib/modules/download/requesters/pdf.rb
+++ b/lib/modules/download/requesters/pdf.rb
@@ -1,6 +1,6 @@
 class Download::Requesters::Pdf < Download::Requesters::Base
   def initialize token
-    # token can be WDPAID or ISO
+    # token can be SITE_ID or ISO
     @token = token
   end
 

--- a/lib/modules/download/utils.rb
+++ b/lib/modules/download/utils.rb
@@ -1,45 +1,47 @@
 module Download
   module Utils
-    def self.link_to download_name
+    def self.link_to(download_name)
       file_name = File.basename zip_path(download_name)
       S3.link_to file_name
     end
 
-    def self.download_columns opts={}
-      opts = {reject: []}.merge(opts)
-      add_quotes = -> str { %{"#{str}"} }
+    def self.download_columns(opts = {})
+      opts = { reject: [] }.merge(opts)
+      add_quotes = ->(str) { %("#{str}") }
 
       Download::Queries::POLYGONS_COLUMNS
         .reject { |col| opts[:reject].include? col }
         .map(&:upcase)
         .map(&add_quotes)
-        .join(",")
+        .join(',')
     end
 
     def self.source_columns
-      add_quotes = -> str { %{"#{str}"} }
+      add_quotes = ->(str) { %("#{str}") }
 
       Download::Queries::SOURCE_COLUMNS
         .map(&:upcase)
         .map(&add_quotes)
-        .join(",")
+        .join(',')
     end
 
     def self.clear_downloads
       S3.delete_all S3::CURRENT_PREFIX
-      $redis.keys("downloads:*").each { |d| $redis.del d }
+      $redis.keys('downloads:*').each { |d| $redis.del d }
     end
 
-    def self.zip_path download_name
+    def self.zip_path(download_name)
       path = File.join(TMP_PATH, download_name)
       "#{path}.zip"
     end
 
-    def self.properties key
-      JSON.parse($redis.get(key)) rescue {}
+    def self.properties(key)
+      JSON.parse($redis.get(key))
+    rescue StandardError
+      {}
     end
 
-    def self.key domain, identifier, format
+    def self.key(domain, identifier, format)
       case domain
       when 'search'
         "downloads:searches:#{format}:#{identifier}"
@@ -60,32 +62,33 @@ module Download
       'default' => 'WDPA_WDOECM'
     }.freeze
     # identifier is the search token if domain is search
-    def self.filename domain, identifier, format
+    def self.filename(domain, identifier, format)
       basename = BASENAMES[identifier] || BASENAMES['default']
-      current_wdpa_id = Wdpa::S3.current_wdpa_identifier
-
-      "#{basename}_#{current_wdpa_id}_Public".tap do |base_filename|
+      current_release_label = Release.latest_succeeded_label
+      "#{basename}_#{current_release_label}_Public".tap do |base_filename|
         base_filename << "_#{identifier}" if needs_identifier_suffix?(domain, identifier)
         base_filename << "_#{format}" if format.present? && format != 'gdb'
       end
     end
 
-    def self.extract_filters filters
+    def self.extract_filters(filters)
       _filters = Search::FilterParams.standardise(filters)
       _filters.stringify_keys.slice(*::Search::ALLOWED_FILTERS.map(&:to_s))
     end
 
-    def self.filters_dump filters
+    def self.filters_dump(filters)
       Marshal.dump filters.to_hash.sort.to_json
     end
 
-    def self.search_token term, filters
-      return 'all' if (term.empty? && filters.empty?)
+    def self.search_token(term, filters)
+      return 'all' if term.empty? && filters.empty?
+
       Digest::SHA256.hexdigest(term.to_s + filters_dump(filters))
     end
 
     def self.needs_identifier_suffix?(domain, identifier)
-      return true if %w(search protected_area pdf).include?(domain)
+      return true if %w[search protected_area pdf].include?(domain)
+
       !BASENAMES.keys.include?(identifier)
     end
   end

--- a/lib/modules/wdpa/portal/adapters/protected_areas.rb
+++ b/lib/modules/wdpa/portal/adapters/protected_areas.rb
@@ -9,7 +9,7 @@ module Wdpa
           sample_limit = Wdpa::Portal::ImportRuntimeConfig.sample_limit
           use_checkpoints = Wdpa::Portal::ImportRuntimeConfig.checkpoints?
 
-          Wdpa::Portal::Config::PortalImportConfig.portal_protected_area_views.each do |view_name|
+          Wdpa::Portal::Config::PortalImportConfig.portal_protected_area_materialised_views.each do |view_name|
             total_count = ActiveRecord::Base.connection.select_value("SELECT COUNT(*) FROM #{view_name}").to_i
 
             offset = 0
@@ -38,7 +38,7 @@ module Wdpa
         def count
           total_count = 0
 
-          Wdpa::Portal::Config::PortalImportConfig.portal_protected_area_views.each do |view_name|
+          Wdpa::Portal::Config::PortalImportConfig.portal_protected_area_materialised_views.each do |view_name|
             count_result = ActiveRecord::Base.connection.select_value("SELECT COUNT(*) FROM #{view_name}")
             total_count += count_result.to_i
           end

--- a/lib/modules/wdpa/portal/adapters/sources.rb
+++ b/lib/modules/wdpa/portal/adapters/sources.rb
@@ -6,25 +6,25 @@ module Wdpa
       class Sources
         def each(&block)
           if portal_sources_exist?
-            query = "SELECT * FROM #{Wdpa::Portal::Config::PortalImportConfig.portal_view_for('sources')}"
+            query = "SELECT * FROM #{Wdpa::Portal::Config::PortalImportConfig.portal_materialised_view_for('sources')}"
             ActiveRecord::Base.connection.select_all(query).each(&block)
           else
             raise StandardError,
-              "#{Wdpa::Portal::Config::PortalImportConfig.portal_view_for('sources')} table is required but does not exist"
+              "#{Wdpa::Portal::Config::PortalImportConfig.portal_materialised_view_for('sources')} table is required but does not exist"
           end
         end
 
         def count
           if portal_sources_exist?
-            ActiveRecord::Base.connection.select_value("SELECT COUNT(*) FROM #{Wdpa::Portal::Config::PortalImportConfig.portal_view_for('sources')}").to_i
+            ActiveRecord::Base.connection.select_value("SELECT COUNT(*) FROM #{Wdpa::Portal::Config::PortalImportConfig.portal_materialised_view_for('sources')}").to_i
           else
             raise StandardError,
-              "#{Wdpa::Portal::Config::PortalImportConfig.portal_view_for('sources')} table is required but does not exist"
+              "#{Wdpa::Portal::Config::PortalImportConfig.portal_materialised_view_for('sources')} table is required but does not exist"
           end
         end
 
         def portal_sources_exist?
-          Wdpa::Portal::Managers::ViewManager.view_exists?(Wdpa::Portal::Config::PortalImportConfig.portal_view_for('sources'))
+          Wdpa::Portal::Managers::ViewManager.view_exists?(Wdpa::Portal::Config::PortalImportConfig.portal_materialised_view_for('sources'))
         end
       end
     end

--- a/lib/modules/wdpa/portal/config/portal_import_config.rb
+++ b/lib/modules/wdpa/portal/config/portal_import_config.rb
@@ -11,14 +11,16 @@ module Wdpa
         STAGING_PREFIX = 'staging_'
         BACKUP_PREFIX = 'bk'
 
-        PORTAL_VIEWS = {
+        PORTAL_MATERIALISED_VIEWS = {
           'iso3_agg' => 'portal_iso3_agg',
           'parent_iso3_agg' => 'portal_parent_iso3_agg',
           'int_crit_agg' => 'portal_int_crit_agg',
           'polygons' => 'portal_standard_polygons',
           'points' => 'portal_standard_points',
           'sources' => 'portal_standard_sources',
-          # This view is created by PortalRelease::Preflight.create_portal_downloads_view! in app/services/portal_release/preflight.rb
+        }
+        PORTAL_VIEWS = {
+        # This view is created by PortalRelease::Preflight.create_portal_downloads_view! in app/services/portal_release/preflight.rb
           'downloads' => 'portal_downloads_protected_areas'
         }
 
@@ -167,16 +169,16 @@ module Wdpa
         # PORTAL VIEW UTILITIES
         # ============================================================================
 
-        def self.portal_view_for(type)
-          PORTAL_VIEWS[type]
+        def self.portal_materialised_view_for(type)
+          PORTAL_MATERIALISED_VIEWS[type]
         end
 
-        def self.portal_views
-          PORTAL_VIEWS.values
+        def self.portal_materialised_view_values
+          PORTAL_MATERIALISED_VIEWS.values
         end
 
-        def self.portal_protected_area_views
-          PORTAL_PROTECTED_AREA_VIEW_TYPES.map { |type| PORTAL_VIEWS[type] }
+        def self.portal_protected_area_materialised_views
+          PORTAL_PROTECTED_AREA_VIEW_TYPES.map { |type| PORTAL_MATERIALISED_VIEWS[type] }
         end
 
         # ============================================================================

--- a/lib/modules/wdpa/portal/config/portal_import_config.rb
+++ b/lib/modules/wdpa/portal/config/portal_import_config.rb
@@ -17,7 +17,8 @@ module Wdpa
           'int_crit_agg' => 'portal_int_crit_agg',
           'polygons' => 'portal_standard_polygons',
           'points' => 'portal_standard_points',
-          'sources' => 'portal_standard_sources'
+          'sources' => 'portal_standard_sources',
+          'downloads' => 'portal_downloads_protected_areas'
         }
 
         # Portal views that contain protected area data (for parcel logic)

--- a/lib/modules/wdpa/portal/config/portal_import_config.rb
+++ b/lib/modules/wdpa/portal/config/portal_import_config.rb
@@ -46,6 +46,17 @@ module Wdpa
           2
         end
 
+        # Progress notification settings for large imports
+        def self.progress_notification_interval
+          # Send progress update every N records
+          50000
+        end
+
+        def self.progress_notifications_enabled?
+          # Enable/disable progress notifications (default: true)
+          ENV['PP_IMPORT_PROGRESS_NOTIFICATIONS'] != 'false'
+        end
+
         # ============================================================================
         # TABLE DEFINITIONS
         # ============================================================================

--- a/lib/modules/wdpa/portal/config/portal_import_config.rb
+++ b/lib/modules/wdpa/portal/config/portal_import_config.rb
@@ -18,6 +18,7 @@ module Wdpa
           'polygons' => 'portal_standard_polygons',
           'points' => 'portal_standard_points',
           'sources' => 'portal_standard_sources',
+          # This view is created by PortalRelease::Preflight.create_portal_downloads_view! in app/services/portal_release/preflight.rb
           'downloads' => 'portal_downloads_protected_areas'
         }
 

--- a/lib/modules/wdpa/portal/importer.rb
+++ b/lib/modules/wdpa/portal/importer.rb
@@ -3,7 +3,8 @@
 module Wdpa
   module Portal
     class Importer < Wdpa::Shared::ImporterBase::Base
-      def self.import(refresh_materialized_views: true, only: nil, skip: nil, sample: nil, label: nil)
+      def self.import(refresh_materialized_views: true, only: nil, skip: nil, sample: nil, label: nil, notifier: nil)
+        notifier&.phase('Start running all importers.')
         unless Wdpa::Portal::Managers::ViewManager.validate_required_views_exist
           error_msg = 'Required materialized views do not exist.'
           raise StandardError, error_msg
@@ -11,10 +12,10 @@ module Wdpa
 
         # Apply runtime flags
         Wdpa::Portal::ImportRuntimeConfig.reset!
-        Wdpa::Portal::ImportRuntimeConfig.only = only || ENV['PP_IMPORT_ONLY']
-        Wdpa::Portal::ImportRuntimeConfig.skip = skip || ENV['PP_IMPORT_SKIP']
-        Wdpa::Portal::ImportRuntimeConfig.sample = sample || ENV['PP_IMPORT_SAMPLE']
-        Wdpa::Portal::ImportRuntimeConfig.label = label || ENV['PP_RELEASE_LABEL']
+        Wdpa::Portal::ImportRuntimeConfig.only = only || ENV.fetch('PP_IMPORT_ONLY', nil)
+        Wdpa::Portal::ImportRuntimeConfig.skip = skip || ENV.fetch('PP_IMPORT_SKIP', nil)
+        Wdpa::Portal::ImportRuntimeConfig.sample = sample || ENV.fetch('PP_IMPORT_SAMPLE', nil)
+        Wdpa::Portal::ImportRuntimeConfig.label = label || ENV.fetch('PP_RELEASE_LABEL', nil)
         Wdpa::Portal::ImportRuntimeConfig.checkpoints_enabled = (ENV['PP_IMPORT_CHECKPOINTS_DISABLE'] != 'true')
 
         # Refresh materialized views to ensure latest data (only if refresh_views is true)
@@ -25,16 +26,16 @@ module Wdpa
         # Check again if still not there then raise an error
         Wdpa::Portal::Managers::StagingTableManager.ensure_staging_tables_exist!(create_if_missing: false)
 
-        staging_tables_results = import_data_to_staging_tables
-        live_tables_results = update_data_in_live_tables
+        staging_tables_results = import_data_to_staging_tables(notifier)
+        live_tables_results = update_data_in_live_tables(notifier: notifier)
 
         # Check for hard errors by checking if any nested keys 'hard_errors'
         # All importers should return hash using build_result, failure_result in Wdpa::Shared::ImporterBase
-        has_hard_errors = check_for_hard_errors(staging_tables_results, live_tables_results)
+        all_hard_errors = check_for_hard_errors(staging_tables_results, live_tables_results)
 
         {
-          success: !has_hard_errors,
-          hard_errors: has_hard_errors ? ['Import completed with hard errors. Check the results for more details. If hard errors are arounce protected areas then you must re-run the import again otherwise you can run individual importers to re-import. See import_data_to_staging_tables, update_data_in_live_tables functions to understand the importer orders'] : []
+          success: all_hard_errors.empty?,
+          hard_errors: all_hard_errors
         }.merge(staging_tables_results).merge(live_tables_results)
       rescue StandardError => e
         Rails.logger.error "Portal import failed: #{e.message}"
@@ -44,7 +45,7 @@ module Wdpa
         })
       end
 
-      def self.import_data_to_staging_tables
+      def self.import_data_to_staging_tables(notifier = nil)
         only = Wdpa::Portal::ImportRuntimeConfig.only_list
         skip = Wdpa::Portal::ImportRuntimeConfig.skip_list
 
@@ -53,22 +54,24 @@ module Wdpa
           n = name.to_s
           return false if skip.include?(n)
           return true if only.empty?
+
           only.include?(n)
         end
 
-        sources_result = should_run.call('sources') ? Wdpa::Portal::Importers::Source.import_to_staging : success_result(0)
-        protected_areas_result = should_run.call('protected_areas') ? Wdpa::Portal::Importers::ProtectedArea.import_to_staging : success_result(0)
+        sources_result = should_run.call('sources') ? Wdpa::Portal::Importers::Source.import_to_staging(notifier: notifier) : success_result(0)
+        protected_areas_result = should_run.call('protected_areas') ? Wdpa::Portal::Importers::ProtectedArea.import_to_staging(notifier: notifier) : success_result(0)
 
         if protected_areas_result[:hard_errors].empty?
-          global_stats_result = should_run.call('global_stats') ? Wdpa::Shared::Importer::GlobalStats.import_to_staging : success_result(0)
-          green_list_result = should_run.call('green_list') ? Wdpa::Portal::Importers::GreenList.import_to_staging : success_result(0)
-          pame_result = should_run.call('pame') ? Wdpa::Portal::Importers::Pame.import_to_staging : success_result(0)
-          story_map_links_result = should_run.call('story_map_links') ? Wdpa::Shared::Importer::StoryMapLinkList.import_to_staging : success_result(0)
+          global_stats_result = should_run.call('global_stats') ? Wdpa::Shared::Importer::GlobalStats.import_to_staging(notifier: notifier) : success_result(0)
+          green_list_result = should_run.call('green_list') ? Wdpa::Portal::Importers::GreenList.import_to_staging(notifier: notifier) : success_result(0)
+          pame_result = should_run.call('pame') ? Wdpa::Portal::Importers::Pame.import_to_staging(notifier: notifier) : success_result(0)
+          story_map_links_result = should_run.call('story_map_links') ? Wdpa::Shared::Importer::StoryMapLinkList.import_to_staging(notifier: notifier) : success_result(0)
           country_statistics_result = if should_run.call('country_statistics')
-                                         Wdpa::Portal::Importers::CountryStatistics.import_to_staging
-                                       else
-                                         { country_pa_geometry: success_result(0), country_general_stats: success_result(0), country_pame_stats: success_result(0) }
-                                       end
+                                        Wdpa::Portal::Importers::CountryStatistics.import_to_staging(notifier: notifier)
+                                      else
+                                        { country_pa_geometry: success_result(0),
+                                          country_general_stats: success_result(0), country_pame_stats: success_result(0) }
+                                      end
         else
           # Skip subsequent importers due to hard errors in protected_areas
           errors = failure_result('Skipped due to hard errors in protected areas importer')
@@ -95,11 +98,11 @@ module Wdpa
       end
 
       # The importers here update data in live country table
-      def self.update_data_in_live_tables
+      def self.update_data_in_live_tables(notifier: nil)
         {
-          country_overseas_territories: Wdpa::Shared::Importer::CountryOverseasTerritories.update_live_table, # not depending on any importer
-          biopama_countries: Wdpa::Shared::Importer::BiopamaCountries.update_live_table, # As of 05Sep2025 it might not used # not depending on any importer
-          aichi11_target: Aichi11Target.update_live_table # As of 05Sep2025 it is probably not used # not depending on any importer
+          country_overseas_territories: Wdpa::Shared::Importer::CountryOverseasTerritories.update_live_table(notifier: notifier), # not depending on any importer
+          biopama_countries: Wdpa::Shared::Importer::BiopamaCountries.update_live_table(notifier: notifier), # As of 05Sep2025 it might not used # not depending on any importer
+          aichi11_target: Aichi11Target.update_live_table(notifier: notifier) # As of 05Sep2025 it is probably not used # not depending on any importer
         }
       end
 
@@ -109,27 +112,32 @@ module Wdpa
 
       def self.check_for_hard_errors(staging_results, live_results)
         all_results = staging_results.merge(live_results)
+        all_errors = []
 
-        all_results.any? do |importer_name, result|
-          check_for_hard_errors_recursive(result, importer_name)
+        all_results.each do |importer_name, result|
+          check_for_hard_errors_recursive(result, importer_name, all_errors)
         end
+
+        all_errors
       end
 
-      def self.check_for_hard_errors_recursive(hash, path_prefix)
-        return false unless hash.is_a?(Hash)
+      def self.check_for_hard_errors_recursive(hash, path_prefix, all_errors)
+        return unless hash.is_a?(Hash)
 
         # Check current level for hard errors
         if hash[:hard_errors]&.any?
           Rails.logger.error "Hard errors found in #{path_prefix}: #{hash[:hard_errors].join(', ')}"
-          return true
+          hash[:hard_errors].each do |error|
+            all_errors << "#{path_prefix}: #{error}"
+          end
         end
 
         # Recursively check all nested hashes
-        hash.any? do |key, value|
-          next false unless value.is_a?(Hash)
-          next false if key == :hard_errors # Skip hard_errors keys
+        hash.each do |key, value|
+          next unless value.is_a?(Hash)
+          next if key == :hard_errors # Skip hard_errors keys
 
-          check_for_hard_errors_recursive(value, "#{path_prefix}.#{key}")
+          check_for_hard_errors_recursive(value, "#{path_prefix}.#{key}", all_errors)
         end
       end
     end

--- a/lib/modules/wdpa/portal/importers/country_statistics.rb
+++ b/lib/modules/wdpa/portal/importers/country_statistics.rb
@@ -12,12 +12,13 @@ module Wdpa
           ::Utilities::Files.latest_file_by_glob('lib/data/seeds/pame_country_statistics_*.csv')
         end
 
-        def self.import_to_staging
+        def self.import_to_staging(notifier: nil)
           country_result = import_country_statistics
           pame_result = import_pame_statistics
           geometry_result = Wdpa::Portal::Importers::CountriesProtectedAreaGeometryStatistics.import_to_staging
 
-          Rails.logger.info 'Country statistics import completed'
+          Rails.logger.info "Country PA geometry: #{geometry_result[:imported_count]}, Country general stats: #{country_result[:imported_count]}, Country PAME: #{pame_result[:imported_count]}"
+          notifier&.phase("#{geometry_result[:imported_count]} Country PA geometry, #{country_result[:imported_count]} Country general, #{pame_result[:imported_count]} Country PAME imported")
           {
             country_pa_geometry: geometry_result,
             country_general_stats: country_result,

--- a/lib/modules/wdpa/portal/importers/green_list.rb
+++ b/lib/modules/wdpa/portal/importers/green_list.rb
@@ -22,10 +22,14 @@ module Wdpa
   module Portal
     module Importers
       class GreenList < Base
-        def self.import_to_staging
+        def self.import_to_staging(notifier: nil)
           clear_existing_data
-          process_csv_file
+          results = process_csv_file
+
+          notifier&.phase("#{results[:imported_count]} Green list import completed")
+          results
         rescue StandardError => e
+          notifier&.phase("Import failed: #{e.message}")
           failure_result("Import failed: #{e.message}", 0)
         end
 

--- a/lib/modules/wdpa/portal/importers/pame.rb
+++ b/lib/modules/wdpa/portal/importers/pame.rb
@@ -10,7 +10,7 @@ module Wdpa
           ::Utilities::Files.latest_file_by_glob('lib/data/seeds/pame_data_*.csv')
         end
 
-        def self.import_to_staging(csv_file = nil)
+        def self.import_to_staging(csv_file = nil, notifier: nil)
           Rails.logger.info 'Deleting old staging PAME evaluations...'
           Staging::PameEvaluation.delete_all
           Rails.logger.info 'Importing staging PAME evaluations...'
@@ -94,13 +94,16 @@ module Wdpa
 
           Rails.logger.info 'Staging PAME import completed successfully'
           Rails.logger.info "Total PAME evaluations imported: #{total_evaluations}"
+          notifier&.phase("#{total_evaluations} PAME evaluations imported.")
           Rails.logger.info "Total PAME sources imported: #{total_sources}"
+          
 
           build_result(total_evaluations, soft_errors, [], {
             total_sources: total_sources,
             site_ids_not_recognised: site_ids_not_recognised
           })
         rescue StandardError => e
+          notifier&.phase("Import PAME evaluations failed. #{e.message}")
           failure_result("Import failed: #{e.message}", 0)
         end
       end

--- a/lib/modules/wdpa/portal/importers/protected_area.rb
+++ b/lib/modules/wdpa/portal/importers/protected_area.rb
@@ -4,18 +4,18 @@ module Wdpa
   module Portal
     module Importers
       class ProtectedArea < Base
-        def self.import_to_staging
+        def self.import_to_staging(notifier: nil)
           Rails.logger.info 'Starting comprehensive protected area import to staging tables...'
 
           start_time = Time.current
-          attributes_result = import_attributes
-          geometry_result = import_geometries
+          attributes_result = import_attributes(notifier: notifier)
+          geometry_result = import_geometries(notifier: notifier)
 
           # Only run related sources if no hard errors from previous imports
           related_sources_result = if attributes_result[:hard_errors].empty? && geometry_result[:protected_areas][:hard_errors].empty? && geometry_result[:protected_area_parcels][:hard_errors].empty?
                                      import_related_sources
                                    else
-                                    error_msg = 'Skipping related sources import due to hard errors in attributes or geometry imports'
+                                     error_msg = 'Skipping related sources import due to hard errors in attributes or geometry imports'
                                      Rails.logger.warn error_msg
                                      {
                                        parcc: failure_result(error_msg, 0),
@@ -24,9 +24,13 @@ module Wdpa
                                    end
 
           duration_hours = (Time.current - start_time) / 3600.0
-          has_hard_errors = attributes_result[:hard_errors].any? ||
-          geometry_result[:protected_areas][:hard_errors].any? || 
-          geometry_result[:protected_area_parcels][:hard_errors].any? ? ["Hard errors detected in the protected area import"] : []
+          has_hard_errors = if attributes_result[:hard_errors].any? ||
+                               geometry_result[:protected_areas][:hard_errors].any? ||
+                               geometry_result[:protected_area_parcels][:hard_errors].any?
+                              ['Hard errors detected in the protected area import']
+                            else
+                              []
+                            end
           Rails.logger.info "Protected Area Import completed in #{duration_hours.round(2)} hours"
 
           {
@@ -40,8 +44,8 @@ module Wdpa
 
         private
 
-        def self.import_attributes
-          result = Wdpa::Portal::Importers::ProtectedArea::Attribute.import_to_staging
+        def self.import_attributes(notifier: nil)
+          result = Wdpa::Portal::Importers::ProtectedArea::Attribute.import_to_staging(notifier: notifier)
           Rails.logger.info "✓ Attributes imported: #{result[:imported_count]} records"
           result
         rescue StandardError => e
@@ -50,12 +54,11 @@ module Wdpa
           failure_result(error_msg, 0)
         end
 
-        def self.import_geometries
-          result = Wdpa::Portal::Importers::ProtectedArea::Geometry.import_to_staging
-          Rails.logger.info "✓ Geometries imported: #{result[:imported_count]} records"
-          result
+        def self.import_geometries(notifier: nil)
+          Wdpa::Portal::Importers::ProtectedArea::Geometry.import_to_staging(notifier: notifier)
         rescue StandardError => e
           error_msg = "Failed to import protected area geometries: #{e.message}"
+          notifier&.phase("Failed to import protected area geometries: #{e.message}")
           Rails.logger.error error_msg
           failure_result(error_msg, 0)
         end

--- a/lib/modules/wdpa/portal/importers/protected_area/attribute.rb
+++ b/lib/modules/wdpa/portal/importers/protected_area/attribute.rb
@@ -107,7 +107,7 @@ module Wdpa
         def self.get_site_ids_with_multiple_site_pids_map
           sites_with_multiple_parcels = {}
 
-          Wdpa::Portal::Config::PortalImportConfig.portal_protected_area_views.each do |view|
+          Wdpa::Portal::Config::PortalImportConfig.portal_protected_area_materialised_views.each do |view|
             # Find WDPA IDs that have more than one parcel
             find_site_ids_with_multiple_parcels_command = <<~SQL
               SELECT site_id, MIN(site_pid) AS first_site_pid

--- a/lib/modules/wdpa/portal/importers/protected_area/attribute.rb
+++ b/lib/modules/wdpa/portal/importers/protected_area/attribute.rb
@@ -4,7 +4,7 @@ module Wdpa
   module Portal
     module Importers
       class ProtectedArea::Attribute < Base
-        def self.import_to_staging
+        def self.import_to_staging(notifier: nil)
           # Import protected area attributes (non-spatial data only) to staging tables
           # Handles both Staging::ProtectedArea and Staging::ProtectedAreaParcel
           # Geometry data is handled separately by GeometryImporter
@@ -15,23 +15,44 @@ module Wdpa
           adapter = Wdpa::Portal::Adapters::ImportViewsAdapter.new
           relation = adapter.protected_areas_relation
 
+          # Get total count for progress tracking
+          total_count = relation.count
+          Rails.logger.info "Starting protected area attributes import: #{total_count} records"
+
           imported_count = 0
+          imported_pa_count = 0
+          imported_parcel_count = 0
           soft_errors = []
+          progress_interval = Wdpa::Portal::Config::PortalImportConfig.progress_notification_interval
 
           relation.find_in_batches do |batch|
             batch_result = process_batch(batch, site_ids_with_multiple_site_pids)
             imported_count += batch_result[:count]
+            imported_pa_count += (batch_result[:pa_count] || 0)
+            imported_parcel_count += (batch_result[:parcel_count] || 0)
             soft_errors.concat(batch_result[:soft_errors])
+
+            # Send progress notification if we've hit the interval
+            if notifier && imported_count % progress_interval == 0
+              notifier.progress(imported_count, total_count, 'protected area attributes')
+            end
           rescue StandardError => e
             Rails.logger.error("Batch processing failed: #{e.message}")
             raise e # Re-raise as hard error to stop import
           end
+          Rails.logger.info "#{imported_pa_count} Protected area attributes imported, #{imported_parcel_count} Protected area parcel attributes imported"
+          notifier&.phase("#{imported_pa_count} Protected area attributes imported, #{imported_parcel_count} Protected area parcel attributes imported")
 
-          build_result(imported_count, soft_errors, [])
+          build_result(imported_count, soft_errors, [], {
+            protected_areas_imported_count: imported_pa_count,
+            protected_area_parcels_imported_count: imported_parcel_count
+          })
         end
 
         def self.process_batch(batch, site_ids_with_multiple_site_pids)
           imported_count = 0
+          imported_pa_count = 0
+          imported_parcel_count = 0
           soft_errors = []
 
           batch.each do |pa_attributes|
@@ -46,6 +67,7 @@ module Wdpa
                 pa_attrs = Wdpa::Portal::Utils::ColumnMapper.map_portal_to_pp_protected_area(pa_attributes)
                 Staging::ProtectedArea.create!(pa_attrs)
                 imported_count += 1
+                imported_pa_count += 1
               end
 
               # Always add to parcels if there are multiple parcels (including the first one)
@@ -54,14 +76,20 @@ module Wdpa
                 Staging::ProtectedAreaParcel.create!(parcel_attrs)
                 # Don't count the first parcel as it's already counted in protected_area
                 # Only count additional parcels (when add_to_protected_areas is false)
-                imported_count += 1 unless add_to_protected_areas
+                unless add_to_protected_areas
+                  imported_count += 1
+                  imported_parcel_count += 1
+                end
               end
             end
           rescue StandardError => e
             soft_errors << "Row error processing SITE_ID #{pa_attributes['site_id']} SITE_PID #{pa_attributes['site_pid']}: #{e.message}"
           end
 
-          { count: imported_count, soft_errors: soft_errors }
+          { count: imported_count,
+            pa_count: imported_pa_count,
+            parcel_count: imported_parcel_count,
+            soft_errors: soft_errors }
         end
 
         def self.current_entry_parcel_info(protected_area_attributes, site_ids_with_multiple_site_pids)

--- a/lib/modules/wdpa/portal/importers/protected_area/geometry.rb
+++ b/lib/modules/wdpa/portal/importers/protected_area/geometry.rb
@@ -26,7 +26,7 @@ module Wdpa
           soft_errors = []
           hard_errors = []
 
-          Wdpa::Portal::Config::PortalImportConfig.portal_protected_area_views.each do |view|
+          Wdpa::Portal::Config::PortalImportConfig.portal_protected_area_materialised_views.each do |view|
             if Wdpa::Portal::ImportRuntimeConfig.checkpoints? && Wdpa::Portal::Checkpoint.geometry_done?(view)
               Rails.logger.info "Skipping geometry update for #{view} (checkpoint)"
               next

--- a/lib/modules/wdpa/portal/importers/protected_area/geometry.rb
+++ b/lib/modules/wdpa/portal/importers/protected_area/geometry.rb
@@ -4,11 +4,13 @@ module Wdpa
   module Portal
     module Importers
       class ProtectedArea::Geometry < Base
-        def self.import_to_staging
+        def self.import_to_staging(notifier: nil)
           protected_areas_result = import_geometry_for_table(Staging::ProtectedArea.table_name)
           protected_area_parcels_result = import_geometry_for_table(Staging::ProtectedAreaParcel.table_name)
 
-          Rails.logger.info 'Geometry import completed'
+          Rails.logger.info "#{protected_areas_result[:imported_count]} PA Geometries imported ,#{protected_area_parcels_result[:imported_count]} PA parcel geometries imported"
+          notifier&.phase("#{protected_areas_result[:imported_count]} PA Geometries imported, #{protected_area_parcels_result[:imported_count]} PA parcel geometries imported")
+
           {
             protected_areas: protected_areas_result,
             protected_area_parcels: protected_area_parcels_result

--- a/lib/modules/wdpa/portal/importers/source.rb
+++ b/lib/modules/wdpa/portal/importers/source.rb
@@ -4,7 +4,7 @@ module Wdpa
   module Portal
     module Importers
       class Source < Base
-        def self.import_to_staging
+        def self.import_to_staging(notifier: nil)
           adapter = Wdpa::Portal::Adapters::ImportViewsAdapter.new
           relation = adapter.sources_relation
 
@@ -20,8 +20,11 @@ module Wdpa
             Rails.logger.warn "Row processing failed: #{e.message}"
           end
 
+          Rails.logger.info 'Sources imported successfully'
+          notifier&.phase("#{imported_count} Sources imported")
           build_result(imported_count, soft_errors, [])
         rescue StandardError => e
+          notifier&.phase("Import failed: #{e.message}")
           failure_result("Import failed: #{e.message}", 0)
         end
       end

--- a/lib/modules/wdpa/portal/managers/view_manager.rb
+++ b/lib/modules/wdpa/portal/managers/view_manager.rb
@@ -15,7 +15,7 @@ module Wdpa
 
         # Validate that all required views exist (used by importer)
         def self.validate_required_views_exist
-          required_views = Wdpa::Portal::Config::PortalImportConfig.portal_views
+          required_views = Wdpa::Portal::Config::PortalImportConfig.portal_materialised_view_values
 
           missing_views = required_views.select do |view_name|
             !view_exists?(view_name)
@@ -32,10 +32,8 @@ module Wdpa
 
         # Refresh all materialized views before import (with automatic index creation)
         def self.refresh_materialized_views
-          views = Wdpa::Portal::Config::PortalImportConfig.portal_views
+          views = Wdpa::Portal::Config::PortalImportConfig.portal_materialised_view_values
           views.each do |view_name|
-            Rails.logger.info "Refreshing materialized view: #{view_name}"
-
             # Then refresh the view concurrently
             refresh_view_concurrently(view_name)
           end

--- a/lib/modules/wdpa/portal/services/core/table_rollback_service.rb
+++ b/lib/modules/wdpa/portal/services/core/table_rollback_service.rb
@@ -25,7 +25,9 @@ module Wdpa
                 Rails.logger.info '✅ Table rollback completed successfully'
               rescue StandardError => e
                 Rails.logger.error "❌ Table rollback failed: #{e.message}"
-                raise ActiveRecord::Rollback
+                # Re-raise the original error so it propagates to callers
+                # (the transaction will still be rolled back automatically)
+                raise
               end
             rescue StandardError => e
               Rails.logger.error "❌ Transaction failed: #{e.message}"
@@ -189,7 +191,7 @@ module Wdpa
             backup_tables = @connection.tables.select do |table|
               Wdpa::Portal::Config::PortalImportConfig.is_backup_table?(table)
             end
-
+            Rails.logger.info 'ℹ️ The return array will be showing from latest to oldest timestamps.'
             backup_tables
               .map { |table| Wdpa::Portal::Config::PortalImportConfig.extract_backup_timestamp(table) }
               .uniq

--- a/lib/modules/wdpa/portal/services/core/table_rollback_service.rb
+++ b/lib/modules/wdpa/portal/services/core/table_rollback_service.rb
@@ -182,6 +182,7 @@ module Wdpa
           # --- CLEANUP & MONITORING ---
 
           def self.list_available_backups
+            Rails.logger.info 'ℹ️ The return array will be showing from latest to oldest timestamps.'
             service = new
             service.initialize_rollback_variables(nil)
             service.list_available_backups_impl
@@ -191,7 +192,6 @@ module Wdpa
             backup_tables = @connection.tables.select do |table|
               Wdpa::Portal::Config::PortalImportConfig.is_backup_table?(table)
             end
-            Rails.logger.info 'ℹ️ The return array will be showing from latest to oldest timestamps.'
             backup_tables
               .map { |table| Wdpa::Portal::Config::PortalImportConfig.extract_backup_timestamp(table) }
               .uniq

--- a/lib/modules/wdpa/release.rb
+++ b/lib/modules/wdpa/release.rb
@@ -69,7 +69,7 @@ class Wdpa::Release
 
   def create_downloads_view
     create_query = "CREATE OR REPLACE VIEW #{DOWNLOADS_VIEW_NAME} AS "
-    as_query = Download::Queries.mixed(true)
+    as_query = Download::Queries.build_query_for_downloads_view(true)
 
     db.execute(create_query + "(SELECT #{as_query[:select]} FROM #{as_query[:from]})")
   end

--- a/lib/modules/wdpa/shared/importer/biopama_countries.rb
+++ b/lib/modules/wdpa/shared/importer/biopama_countries.rb
@@ -11,7 +11,7 @@ module Wdpa
         # table separation.
         BIOPAMA_COUNTRIES_CSV = "#{Rails.root}/lib/data/seeds/biopama_countries_iso_codes.csv"
 
-        def self.update_live_table
+        def self.update_live_table(notifier: nil)
           countries_updated = 0
           countries_not_found = 0
           soft_errors = []
@@ -41,6 +41,7 @@ module Wdpa
           end
 
           Rails.logger.info "BIOPAMA countries import completed: #{countries_updated} updated, #{countries_not_found} not found"
+          notifier&.phase("BIOPAMA countries import completed: #{countries_updated} updated, #{countries_not_found} not found")
 
           Wdpa::Shared::ImporterBase::Base.build_result(countries_updated, soft_errors, [], {
             countries_updated: countries_updated,

--- a/lib/modules/wdpa/shared/importer/country_overseas_territories.rb
+++ b/lib/modules/wdpa/shared/importer/country_overseas_territories.rb
@@ -12,11 +12,11 @@ module Wdpa
         # staging table separation.
         OVERSEAS_TERRITORIES_CSV = "#{Rails.root}/lib/data/seeds/overseas_territories.csv"
 
-        def self.update_live_table
-          new.update_live_table
+        def self.update_live_table(notifier: nil)
+          new.update_live_table(notifier: notifier)
         end
 
-        def update_live_table
+        def update_live_table(notifier: nil)
           csv = CSV.read(OVERSEAS_TERRITORIES_CSV)
           csv.shift
 
@@ -74,7 +74,8 @@ module Wdpa
             end
           end
 
-          Rails.logger.info "Overseas territories import completed: #{imported_count} relationships created"
+          Rails.logger.info "Overseas territories import completed: #{imported_count} relationships created, already added so skipped: #{info[:already_added_so_skipped]}"
+          notifier&.phase("Overseas territories import completed: #{imported_count} relationships created, already added so skipped: #{info[:already_added_so_skipped]}")
           if info[:parent_country_not_found].any?
             Rails.logger.info "info parent countries not found: #{info[:parent_country_not_found].join(', ')}"
           end

--- a/lib/modules/wdpa/shared/importer/global_stats.rb
+++ b/lib/modules/wdpa/shared/importer/global_stats.rb
@@ -34,7 +34,7 @@ module Wdpa
           Wdpa::Shared::ImporterBase::Base.failure_result("Global statistics import failed: #{e.message}", 0)
         end
 
-        def self.import_to_staging
+        def self.import_to_staging(notifier: nil)
           attrs = { singleton_guard: 0 }
           soft_errors = []
 
@@ -51,11 +51,13 @@ module Wdpa
           stats = Staging::GlobalStatistic.first_or_initialize(attrs)
           stats.update(attrs)
 
-          Rails.logger.info "Global statistics import completed: #{attrs.keys.length} fields updated"
           fields_updated = attrs.keys.length
+          Rails.logger.info "Global statistics import completed: #{fields_updated} fields updated"
+          notifier&.phase("#{fields_updated} Global statistics imported/updated.")
           Wdpa::Shared::ImporterBase::Base.build_result(fields_updated, soft_errors, [],
             { fields_updated: fields_updated })
         rescue StandardError => e
+          notifier&.phase("Global statistics import failed: #{e.message}")
           Rails.logger.error "Global statistics import failed: #{e.message}"
           Wdpa::Shared::ImporterBase::Base.failure_result("Global statistics import failed: #{e.message}", 0)
         end

--- a/lib/modules/wdpa/shared/importer/story_map_link_list.rb
+++ b/lib/modules/wdpa/shared/importer/story_map_link_list.rb
@@ -12,11 +12,13 @@ module Wdpa
           result
         end
 
-        def self.import_to_staging
+        def self.import_to_staging(notifier: nil)
           result = import_data(Staging::ProtectedArea, Staging::StoryMapLink)
           Rails.logger.info "Staging story map links import completed: #{result[:links_processed]} processed, #{result[:links_created]} created, #{result[:sites_not_found]} sites not found"
+          notifier&.phase("Staging story map links import completed: #{result[:links_processed]} processed, #{result[:links_created]} created, #{result[:sites_not_found]} sites not found")
           result
         rescue StandardError => e
+          notifier&.phase("Story map links import failed: #{e.message}")
           Rails.logger.error "Story map links import failed: #{e.message}"
           Wdpa::Shared::ImporterBase::Base.failure_result("Setup error: #{e.message}", 0, {
             links_processed: 0,

--- a/lib/tasks/portal_release.rake
+++ b/lib/tasks/portal_release.rake
@@ -3,7 +3,7 @@ namespace :pp do
     desc "Run portal-backed WDPA release. Usage: rake pp:portal:release['WDPA_YYYY_MM']"
     task :release, [:label] => :environment do |_t, args|
       # Default to e.g. "Mar2025" when no label is supplied
-      label = args[:label] || Time.now.utc.strftime('%b%Y')
+      label = args[:label] || Time.now.utc.advance(months: 1).strftime('%b%Y')
       PortalRelease::Service.new(label: label).run!
     end
 

--- a/lib/tasks/portal_release.rake
+++ b/lib/tasks/portal_release.rake
@@ -3,24 +3,24 @@ namespace :pp do
     desc "Run portal-backed WDPA release. Usage: rake pp:portal:release['WDPA_YYYY_MM']"
     task :release, [:label] => :environment do |_t, args|
       # Default to e.g. "Mar2025" when no label is supplied
+      # Each month we run release for next month data so month +1 is used to get the correct label
       label = args[:label] || Time.now.utc.advance(months: 1).strftime('%b%Y')
       PortalRelease::Service.new(label: label).run!
     end
 
     desc 'Abort current in-flight release (drops staging tables)'
-    task :abort => :environment do
+    task abort: :environment do
       PortalRelease::Service.abort_current!
     end
 
     desc 'Rollback last swapped release (noop until Step 4)'
-    task :rollback => :environment do
+    task rollback: :environment do
       PortalRelease::Service.rollback_last!
     end
 
     desc 'Show release status summary'
-    task :status => :environment do
+    task status: :environment do
       puts PortalRelease::Service.status_report
     end
   end
 end
-

--- a/lib/tasks/portal_release.rake
+++ b/lib/tasks/portal_release.rake
@@ -2,7 +2,8 @@ namespace :pp do
   namespace :portal do
     desc "Run portal-backed WDPA release. Usage: rake pp:portal:release['WDPA_YYYY_MM']"
     task :release, [:label] => :environment do |_t, args|
-      label = args[:label] || Time.now.utc.strftime('WDPA_%Y_%m')
+      # Default to e.g. "Mar2025" when no label is supplied
+      label = args[:label] || Time.now.utc.strftime('%b%Y')
       PortalRelease::Service.new(label: label).run!
     end
 

--- a/test/integration/wdpa/portal/complete_import_workflow_test.rb
+++ b/test/integration/wdpa/portal/complete_import_workflow_test.rb
@@ -108,7 +108,7 @@ class Wdpa::Portal::CompleteImportWorkflowTest < ActionDispatch::IntegrationTest
   def create_test_portal_views_with_new_fields
     # Create test portal views with comprehensive sample data including new fields
     ActiveRecord::Base.connection.execute(<<~SQL)
-      CREATE MATERIALIZED VIEW #{Wdpa::Portal::Config::PortalImportConfig.portal_view_for('polygons')} AS
+      CREATE MATERIALIZED VIEW #{Wdpa::Portal::Config::PortalImportConfig.portal_materialised_view_for('polygons')} AS
       SELECT#{' '}
         1 as wdpaid,
         '1' as wdpa_pid,
@@ -148,7 +148,7 @@ class Wdpa::Portal::CompleteImportWorkflowTest < ActionDispatch::IntegrationTest
         'In Progress' as oecm_assessment,
         ST_GeomFromText('POLYGON((2 2, 3 2, 3 3, 2 3, 2 2))') as wkb_geometry;
 
-      CREATE MATERIALIZED VIEW #{Wdpa::Portal::Config::PortalImportConfig.portal_view_for('points')} AS
+      CREATE MATERIALIZED VIEW #{Wdpa::Portal::Config::PortalImportConfig.portal_materialised_view_for('points')} AS
       SELECT#{' '}
         4 as wdpaid,
         '4' as wdpa_pid,
@@ -175,7 +175,7 @@ class Wdpa::Portal::CompleteImportWorkflowTest < ActionDispatch::IntegrationTest
         'Pending' as oecm_assessment,
         ST_GeomFromText('POINT(1.5 1.5)') as wkb_geometry;
 
-      CREATE MATERIALIZED VIEW #{Wdpa::Portal::Config::PortalImportConfig.portal_view_for('sources')} AS
+      CREATE MATERIALIZED VIEW #{Wdpa::Portal::Config::PortalImportConfig.portal_materialised_view_for('sources')} AS
       SELECT#{' '}
         1 as id,
         'Test Source 1' as title,
@@ -195,7 +195,7 @@ class Wdpa::Portal::CompleteImportWorkflowTest < ActionDispatch::IntegrationTest
   def create_test_portal_views_with_invalid_realm
     # Create test portal views with invalid realm data
     ActiveRecord::Base.connection.execute(<<~SQL)
-      CREATE MATERIALIZED VIEW #{Wdpa::Portal::Config::PortalImportConfig.portal_view_for('polygons')} AS
+      CREATE MATERIALIZED VIEW #{Wdpa::Portal::Config::PortalImportConfig.portal_materialised_view_for('polygons')} AS
       SELECT#{' '}
         1 as wdpaid,
         '1' as wdpa_pid,
@@ -229,7 +229,7 @@ class Wdpa::Portal::CompleteImportWorkflowTest < ActionDispatch::IntegrationTest
   end
 
   def drop_test_portal_views
-    Wdpa::Portal::Config::PortalImportConfig.portal_views.each do |view|
+    Wdpa::Portal::Config::PortalImportConfig.portal_materialised_view_values.each do |view|
       ActiveRecord::Base.connection.execute("DROP MATERIALIZED VIEW IF EXISTS #{view}")
     end
   end

--- a/test/integration/wdpa/portal/import_integration_test.rb
+++ b/test/integration/wdpa/portal/import_integration_test.rb
@@ -44,7 +44,7 @@ class Wdpa::Portal::ImportIntegrationTest < ActionDispatch::IntegrationTest
   def create_test_portal_views
     # Create test portal views with sample data
     ActiveRecord::Base.connection.execute(<<~SQL)
-      CREATE MATERIALIZED VIEW #{Wdpa::Portal::Config::PortalImportConfig.portal_view_for('polygons')} AS
+      CREATE MATERIALIZED VIEW #{Wdpa::Portal::Config::PortalImportConfig.portal_materialised_view_for('polygons')} AS
       SELECT#{' '}
         1 as wdpaid,
         '1' as wdpa_pid,
@@ -61,7 +61,7 @@ class Wdpa::Portal::ImportIntegrationTest < ActionDispatch::IntegrationTest
         'II' as iucn_cat,
         ST_GeomFromText('POLYGON((1 1, 2 1, 2 2, 1 2, 1 1))') as wkb_geometry;
 
-      CREATE MATERIALIZED VIEW #{Wdpa::Portal::Config::PortalImportConfig.portal_view_for('points')} AS
+      CREATE MATERIALIZED VIEW #{Wdpa::Portal::Config::PortalImportConfig.portal_materialised_view_for('points')} AS
       SELECT#{' '}
         3 as wdpaid,
         '3' as wdpa_pid,
@@ -70,7 +70,7 @@ class Wdpa::Portal::ImportIntegrationTest < ActionDispatch::IntegrationTest
         'III' as iucn_cat,
         ST_GeomFromText('POINT(0.5 0.5)') as wkb_geometry;
 
-      CREATE MATERIALIZED VIEW #{Wdpa::Portal::Config::PortalImportConfig.portal_view_for('sources')} AS
+      CREATE MATERIALIZED VIEW #{Wdpa::Portal::Config::PortalImportConfig.portal_materialised_view_for('sources')} AS
       SELECT#{' '}
         1 as id,
         'Test Source' as title,
@@ -81,7 +81,7 @@ class Wdpa::Portal::ImportIntegrationTest < ActionDispatch::IntegrationTest
   end
 
   def drop_test_portal_views
-    Wdpa::Portal::Config::PortalImportConfig.portal_views.each do |view|
+    Wdpa::Portal::Config::PortalImportConfig.portal_materialised_view_values.each do |view|
       ActiveRecord::Base.connection.execute("DROP MATERIALIZED VIEW IF EXISTS #{view}")
     end
   end

--- a/test/unit/download/generators/base_test.rb
+++ b/test/unit/download/generators/base_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class DownloadGeneratorsBaseTest < ActiveSupport::TestCase
-  test '#generate, given a path and an empty array of wdpa_ids,
+  test '#generate, given a path and an empty array of site_ids,
    returns immediately' do
     Download::Generators::Base.any_instance.expects(:export).never
     Download::Generators::Base.any_instance.expects(:zip).never

--- a/test/unit/download/generators/csv_test.rb
+++ b/test/unit/download/generators/csv_test.rb
@@ -79,7 +79,7 @@ class DownloadGeneratorsCsvTest < ActiveSupport::TestCase
     csv_file_path = './all-csv.csv'
     wdpa_file_path = 'WDPA_sources.csv'
 
-    wdpa_ids = [1, 2, 3]
+    site_ids = [1, 2, 3]
     query = "
       SELECT \"TYPE\", #{Download::Utils.download_columns}
       FROM #{Wdpa::Portal::Config::PortalImportConfig::PORTAL_VIEWS['downloads']}
@@ -104,7 +104,7 @@ class DownloadGeneratorsCsvTest < ActiveSupport::TestCase
 
     Ogr::Postgres.expects(:export).with(:csv, csv_file_path, "SELECT * FROM #{view_name}").returns(true)
 
-    assert_equal true, Download::Generators::Csv.generate(zip_file_path, wdpa_ids),
+    assert_equal true, Download::Generators::Csv.generate(zip_file_path, site_ids),
       'Expected #generate to return true on success'
   end
 end

--- a/test/unit/download/generators/csv_test.rb
+++ b/test/unit/download/generators/csv_test.rb
@@ -6,10 +6,10 @@ class DownloadGeneratorsCsvTest < ActiveSupport::TestCase
     zip_file_path = './all-csv.zip'
     csv_file_path = './all-csv.csv'
     wdpa_file_path = 'WDPA_sources.csv'
-    query = """
+    query = "
       SELECT \"TYPE\", #{Download::Utils.download_columns}
-      FROM #{Wdpa::Release::DOWNLOADS_VIEW_NAME}
-    """.squish
+      FROM #{Wdpa::Portal::Config::PortalImportConfig::PORTAL_VIEWS['downloads']}
+    ".squish
 
     File.stubs(:exists?).with('./WDPA_sources.csv').returns(true)
 
@@ -20,17 +20,17 @@ class DownloadGeneratorsCsvTest < ActiveSupport::TestCase
     Download::Generators::Csv.any_instance.expects(:system).with(create_zip_command).returns(true)
 
     wdpa_zip_command = "zip -ru #{zip_file_path} #{wdpa_file_path}"
-    opts = {chdir: "."}
+    opts = { chdir: '.' }
     Download::Generators::Csv.any_instance.expects(:system).with(wdpa_zip_command, opts).returns(true)
 
     update_zip_command = "zip -ru #{zip_file_path} *"
-    opts = {chdir: Download::Generators::Base::ATTACHMENTS_PATH}
+    opts = { chdir: Download::Generators::Base::ATTACHMENTS_PATH }
     Download::Generators::Csv.any_instance.expects(:system).with(update_zip_command, opts).returns(true)
 
     Ogr::Postgres.expects(:export).with(:csv, csv_file_path, "SELECT * FROM #{view_name}").returns(true)
 
     assert_equal true, Download::Generators::Csv.generate(zip_file_path),
-      "Expected #generate to return true on success"
+      'Expected #generate to return true on success'
   end
 
   test '#generate returns false if the export fails' do
@@ -38,7 +38,7 @@ class DownloadGeneratorsCsvTest < ActiveSupport::TestCase
     Ogr::Postgres.expects(:export).returns(false)
 
     assert_equal false, Download::Generators::Csv.generate(''),
-      "Expected #generate to return false on failure"
+      'Expected #generate to return false on failure'
   end
 
   test '#generate returns false if the zip fails' do
@@ -50,15 +50,15 @@ class DownloadGeneratorsCsvTest < ActiveSupport::TestCase
     Download::Generators::Csv.any_instance.expects(:system).returns(false)
 
     wdpa_zip_command = "zip -ru  #{wdpa_file_path}"
-    opts = {chdir: "."}
+    opts = { chdir: '.' }
     Download::Generators::Csv.any_instance.expects(:system).with(wdpa_zip_command, opts).returns(true)
 
-    update_zip_command = "zip -ru  *"
-    opts = {chdir: Download::Generators::Base::ATTACHMENTS_PATH}
+    update_zip_command = 'zip -ru  *'
+    opts = { chdir: Download::Generators::Base::ATTACHMENTS_PATH }
     Download::Generators::Csv.any_instance.expects(:system).with(update_zip_command, opts).returns(false)
 
     assert_equal false, Download::Generators::Csv.generate(''),
-      "Expected #generate to return false on failure"
+      'Expected #generate to return false on failure'
   end
 
   test '#generate removes non-zip files when finished' do
@@ -79,12 +79,12 @@ class DownloadGeneratorsCsvTest < ActiveSupport::TestCase
     csv_file_path = './all-csv.csv'
     wdpa_file_path = 'WDPA_sources.csv'
 
-    wdpa_ids = [1,2,3]
-    query = """
+    wdpa_ids = [1, 2, 3]
+    query = "
       SELECT \"TYPE\", #{Download::Utils.download_columns}
-      FROM #{Wdpa::Release::DOWNLOADS_VIEW_NAME}
-      WHERE \"WDPAID\" IN (1,2,3)
-    """.squish
+      FROM #{Wdpa::Portal::Config::PortalImportConfig::PORTAL_VIEWS['downloads']}
+      WHERE \"SITE_ID\" IN (1,2,3)
+    ".squish
 
     File.stubs(:exists?).with('./WDPA_sources.csv').returns(true)
 
@@ -95,11 +95,11 @@ class DownloadGeneratorsCsvTest < ActiveSupport::TestCase
     Download::Generators::Csv.any_instance.expects(:system).with(create_zip_command).returns(true)
 
     wdpa_zip_command = "zip -ru #{zip_file_path} #{wdpa_file_path}"
-    opts = {chdir: "."}
+    opts = { chdir: '.' }
     Download::Generators::Csv.any_instance.expects(:system).with(wdpa_zip_command, opts).returns(true)
 
     update_zip_command = "zip -ru #{zip_file_path} *"
-    opts = {chdir: Download::Generators::Base::ATTACHMENTS_PATH}
+    opts = { chdir: Download::Generators::Base::ATTACHMENTS_PATH }
     Download::Generators::Csv.any_instance.expects(:system).with(update_zip_command, opts).returns(true)
 
     Ogr::Postgres.expects(:export).with(:csv, csv_file_path, "SELECT * FROM #{view_name}").returns(true)

--- a/test/unit/download/generators/shapefile_test.rb
+++ b/test/unit/download/generators/shapefile_test.rb
@@ -132,7 +132,7 @@ class DownloadShapefileTest < ActiveSupport::TestCase
     shp_point_file_path = './all-shp-points.shp'
     shp_point_joined_files = './all-shp-points.shp ./all-shp-points.shx ./all-shp-points.dbf ./all-shp-points.prj ./all-shp-points.cpg'
 
-    wdpa_ids = [1, 2, 3]
+    site_ids = [1, 2, 3]
 
     shp_polygon_query = "
       SELECT #{Download::Utils.download_columns}
@@ -181,10 +181,10 @@ class DownloadShapefileTest < ActiveSupport::TestCase
     opts = { chdir: Download::Generators::Base::ATTACHMENTS_PATH }
     Download::Generators::Shapefile.any_instance.expects(:system).with(update_zip_command, opts).returns(true)
 
-    Download::Generators::Shapefile.generate zip_file_path, wdpa_ids
+    Download::Generators::Shapefile.generate zip_file_path, site_ids
   end
 
-  test '#generate, given a path and an empty array of wdpa_ids,
+  test '#generate, given a path and an empty array of site_ids,
    returns immediately' do
     Download::Generators::Base.any_instance.expects(:system).never
     Ogr::Postgres.expects(:export).never

--- a/test/unit/download_test.rb
+++ b/test/unit/download_test.rb
@@ -44,7 +44,7 @@ class DownloadTest < ActiveSupport::TestCase
     csv_zip_path = File.join(Rails.root, 'tmp', 'an_download-csv.zip')
     Download::Generators::Csv.expects(:generate).with(csv_zip_path, pa_ids)
 
-    download_success = Download.generate download_name, wdpa_ids: pa_ids
+    download_success = Download.generate download_name, site_ids: pa_ids
     assert download_success, "Expected Download.generate to return true on success"
   end
 

--- a/test/unit/wdpa/portal/adapters/protected_areas_test.rb
+++ b/test/unit/wdpa/portal/adapters/protected_areas_test.rb
@@ -8,10 +8,11 @@ class Wdpa::Portal::Adapters::ProtectedAreasTest < ActiveSupport::TestCase
     # Mock the configuration
     @config = mock('PortalImportConfig')
     @config.stubs(:batch_import_protected_areas_from_view_size).returns(2)
-    @config.stubs(:portal_protected_area_views).returns(%w[portal_standard_polygons portal_standard_points])
+    @config.stubs(:portal_protected_area_materialised_views).returns(%w[portal_standard_polygons
+      portal_standard_points])
 
     Wdpa::Portal::Config::PortalImportConfig.stubs(:batch_import_protected_areas_from_view_size).returns(@config.batch_import_protected_areas_from_view_size)
-    Wdpa::Portal::Config::PortalImportConfig.stubs(:portal_protected_area_views).returns(@config.portal_protected_area_views)
+    Wdpa::Portal::Config::PortalImportConfig.stubs(:portal_protected_area_materialised_views).returns(@config.portal_protected_area_materialised_views)
   end
 
   def teardown
@@ -86,7 +87,7 @@ class Wdpa::Portal::Adapters::ProtectedAreasTest < ActiveSupport::TestCase
 
   test 'find_in_batches handles single view' do
     # Mock single view
-    @config.stubs(:portal_protected_area_views).returns(['portal_standard_polygons'])
+    @config.stubs(:portal_protected_area_materialised_views).returns(['portal_standard_polygons'])
 
     # Create test materialized view
     @connection.execute(<<~SQL)
@@ -150,7 +151,7 @@ class Wdpa::Portal::Adapters::ProtectedAreasTest < ActiveSupport::TestCase
 
   test 'count handles single view' do
     # Mock single view
-    @config.stubs(:portal_protected_area_views).returns(['portal_standard_polygons'])
+    @config.stubs(:portal_protected_area_materialised_views).returns(['portal_standard_polygons'])
 
     # Create test materialized view
     @connection.execute(<<~SQL)

--- a/test/unit/wdpa/portal/adapters/sources_test.rb
+++ b/test/unit/wdpa/portal/adapters/sources_test.rb
@@ -7,9 +7,9 @@ class Wdpa::Portal::Adapters::SourcesTest < ActiveSupport::TestCase
 
     # Mock the configuration
     @config = mock('PortalImportConfig')
-    @config.stubs(:portal_view_for).with('sources').returns('portal_standard_sources')
+    @config.stubs(:portal_materialised_view_for).with('sources').returns('portal_standard_sources')
 
-    Wdpa::Portal::Config::PortalImportConfig.stubs(:portal_view_for).with('sources').returns(@config.portal_view_for('sources'))
+    Wdpa::Portal::Config::PortalImportConfig.stubs(:portal_materialised_view_for).with('sources').returns(@config.portal_materialised_view_for('sources'))
   end
 
   def teardown

--- a/test/unit/wdpa/portal/config/portal_import_config_test.rb
+++ b/test/unit/wdpa/portal/config/portal_import_config_test.rb
@@ -10,7 +10,7 @@ class Wdpa::Portal::Config::PortalImportConfigTest < ActiveSupport::TestCase
     assert_equal 'bk', Wdpa::Portal::Config::PortalImportConfig::BACKUP_PREFIX
   end
 
-  test 'portal_views contains all required views' do
+  test 'portal_materialised_view_values contains all required views' do
     expected_views = {
       'iso3_agg' => 'portal_iso3_agg',
       'parent_iso3_agg' => 'portal_parent_iso3_agg',
@@ -20,7 +20,7 @@ class Wdpa::Portal::Config::PortalImportConfigTest < ActiveSupport::TestCase
       'sources' => 'portal_standard_sources'
     }
 
-    assert_equal expected_views, @config::PORTAL_VIEWS
+    assert_equal expected_views, @config::PORTAL_MATERIALISED_VIEWS
   end
 
   test 'portal_protected_area_view_types contains correct types' do
@@ -197,19 +197,19 @@ class Wdpa::Portal::Config::PortalImportConfigTest < ActiveSupport::TestCase
     assert_nil result
   end
 
-  test 'portal_view_for returns correct view name' do
-    assert_equal 'portal_standard_polygons', @config.portal_view_for('polygons')
-    assert_equal 'portal_standard_points', @config.portal_view_for('points')
-    assert_equal 'portal_standard_sources', @config.portal_view_for('sources')
+  test 'portal_materialised_view_for returns correct view name' do
+    assert_equal 'portal_standard_polygons', @config.portal_materialised_view_for('polygons')
+    assert_equal 'portal_standard_points', @config.portal_materialised_view_for('points')
+    assert_equal 'portal_standard_sources', @config.portal_materialised_view_for('sources')
   end
 
-  test 'portal_view_for returns nil for unknown view type' do
-    result = @config.portal_view_for('unknown')
+  test 'portal_materialised_view_for returns nil for unknown view type' do
+    result = @config.portal_materialised_view_for('unknown')
     assert_nil result
   end
 
-  test 'portal_views returns all view names' do
-    result = @config.portal_views
+  test 'portal_materialised_view_values returns all view names' do
+    result = @config.portal_materialised_view_values
 
     expected = %w[
       portal_iso3_agg
@@ -223,8 +223,8 @@ class Wdpa::Portal::Config::PortalImportConfigTest < ActiveSupport::TestCase
     assert_equal expected, result
   end
 
-  test 'portal_protected_area_views returns protected area view names' do
-    result = @config.portal_protected_area_views
+  test 'portal_protected_area_materialised_views returns protected area view names' do
+    result = @config.portal_protected_area_materialised_views
 
     expected = %w[portal_standard_polygons portal_standard_points]
     assert_equal expected, result

--- a/test/unit/wdpa/portal/importer_test.rb
+++ b/test/unit/wdpa/portal/importer_test.rb
@@ -4,10 +4,10 @@ class Wdpa::Portal::ImporterTest < ActiveSupport::TestCase
   def setup
     # Mock the configuration
     @config = mock('PortalImportConfig')
-    @config.stubs(:portal_views).returns(%w[portal_standard_polygons portal_standard_points
+    @config.stubs(:portal_materialised_view_values).returns(%w[portal_standard_polygons portal_standard_points
       portal_standard_sources])
 
-    Wdpa::Portal::Config::PortalImportConfig.stubs(:portal_views).returns(@config.portal_views)
+    Wdpa::Portal::Config::PortalImportConfig.stubs(:portal_materialised_view_values).returns(@config.portal_materialised_view_values)
   end
 
   test '.import validates views and imports data to staging tables' do

--- a/test/unit/wdpa/portal/managers/view_manager_test.rb
+++ b/test/unit/wdpa/portal/managers/view_manager_test.rb
@@ -6,10 +6,10 @@ class Wdpa::Portal::Managers::ViewManagerTest < ActiveSupport::TestCase
 
     # Mock the configuration
     @config = mock('PortalImportConfig')
-    @config.stubs(:portal_views).returns(%w[portal_standard_polygons portal_standard_points
+    @config.stubs(:portal_materialised_view_values).returns(%w[portal_standard_polygons portal_standard_points
       portal_standard_sources])
 
-    Wdpa::Portal::Config::PortalImportConfig.stubs(:portal_views).returns(@config.portal_views)
+    Wdpa::Portal::Config::PortalImportConfig.stubs(:portal_materialised_view_values).returns(@config.portal_materialised_view_values)
   end
 
   def teardown
@@ -177,8 +177,8 @@ class Wdpa::Portal::Managers::ViewManagerTest < ActiveSupport::TestCase
 
   test 'refresh_materialized_views with empty view list' do
     # Mock empty view list
-    @config.stubs(:portal_views).returns([])
-    Wdpa::Portal::Config::PortalImportConfig.stubs(:portal_views).returns([])
+    @config.stubs(:portal_materialised_view_values).returns([])
+    Wdpa::Portal::Config::PortalImportConfig.stubs(:portal_materialised_view_values).returns([])
 
     # Should complete without error
     assert_nothing_raised do
@@ -188,8 +188,8 @@ class Wdpa::Portal::Managers::ViewManagerTest < ActiveSupport::TestCase
 
   test 'validate_required_views_exist with empty view list' do
     # Mock empty view list
-    @config.stubs(:portal_views).returns([])
-    Wdpa::Portal::Config::PortalImportConfig.stubs(:portal_views).returns([])
+    @config.stubs(:portal_materialised_view_values).returns([])
+    Wdpa::Portal::Config::PortalImportConfig.stubs(:portal_materialised_view_values).returns([])
 
     result = Wdpa::Portal::Managers::ViewManager.validate_required_views_exist
     assert result

--- a/test/unit/workers/download_workers/general_test.rb
+++ b/test/unit/workers/download_workers/general_test.rb
@@ -5,29 +5,29 @@ class DownloadWorkersGeneralTest < ActiveSupport::TestCase
     Wdpa::S3.stubs(:current_wdpa_identifier).returns('Jun2015')
   end
 
-  test '.perform, called with type general, generates a download with all wdpa_ids' do
-    Download.expects(:generate).with('WDPA_Jun2015', {wdpa_ids: nil})
+  test '.perform, called with type general, generates a download with all site_ids' do
+    Download.expects(:generate).with('WDPA_Jun2015', { site_ids: nil })
 
     DownloadWorkers::General.new.perform('general', 'all')
   end
 
-  test '.perform, called with type country, generates a download with all wdpa_ids from a country' do
+  test '.perform, called with type country, generates a download with all site_ids from a country' do
     country = FactoryGirl.create(:country, iso_3: 'USA')
     pa1 = FactoryGirl.create(:protected_area, countries: [country])
     pa2 = FactoryGirl.create(:protected_area, countries: [country])
 
-    Download.expects(:generate).with('WDPA_Jun2015_USA', {wdpa_ids: [pa1.wdpa_id, pa2.wdpa_id]})
+    Download.expects(:generate).with('WDPA_Jun2015_USA', { site_ids: [pa1.wdpa_id, pa2.wdpa_id] })
 
     DownloadWorkers::General.new.perform('country', 'USA')
   end
 
-  test '.perform, called with type region, generates a download with all wdpa_ids from a region' do
+  test '.perform, called with type region, generates a download with all site_ids from a region' do
     region = FactoryGirl.create(:region, iso: 'NA')
     country = FactoryGirl.create(:country, iso_3: 'USA', region: region)
     pa1 = FactoryGirl.create(:protected_area, countries: [country])
     pa2 = FactoryGirl.create(:protected_area, countries: [country])
 
-    Download.expects(:generate).with('WDPA_Jun2015_NA', {wdpa_ids: [pa1.wdpa_id, pa2.wdpa_id]})
+    Download.expects(:generate).with('WDPA_Jun2015_NA', { site_ids: [pa1.wdpa_id, pa2.wdpa_id] })
 
     DownloadWorkers::General.new.perform('region', 'NA')
   end

--- a/test/unit/workers/download_workers/search_test.rb
+++ b/test/unit/workers/download_workers/search_test.rb
@@ -8,114 +8,112 @@ class DownloadWorkersSearchTest < ActiveSupport::TestCase
    ids' do
     query_term = 'manbone'
     token = '12345'
-    pa_ids = [1,2,3,4]
+    pa_ids = [1, 2, 3, 4]
     digested_pa_ids = '03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4'
 
-    saved_search_mock = mock()
-    saved_search_mock.stubs(:wdpa_ids).returns(pa_ids)
+    saved_search_mock = mock
+    saved_search_mock.stubs(:site_ids).returns(pa_ids)
     saved_search_mock.stubs(:properties).returns({})
     saved_search_mock.stubs(:complete!)
-    SavedSearch.expects(:new).
-      with(search_term: query_term, filters: '{}').
-      returns(saved_search_mock)
+    SavedSearch.expects(:new)
+      .with(search_term: query_term, filters: '{}')
+      .returns(saved_search_mock)
 
-    Download.expects(:generate).
-      with("WDPA_Jun2015_search_manbone_#{digested_pa_ids}", {wdpa_ids: pa_ids})
+    Download.expects(:generate)
+      .with("WDPA_Jun2015_search_manbone_#{digested_pa_ids}", { site_ids: pa_ids })
 
     DownloadWorkers::Search.new.perform token, query_term, {}.to_json
   end
 
   test '.perform executes a search and generates a download with no search term' do
     token = '12345'
-    pa_ids = [1,2,3,4]
+    pa_ids = [1, 2, 3, 4]
     digested_pa_ids = '03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4'
 
-    saved_search_mock = mock()
-    saved_search_mock.stubs(:wdpa_ids).returns(pa_ids)
+    saved_search_mock = mock
+    saved_search_mock.stubs(:site_ids).returns(pa_ids)
     saved_search_mock.stubs(:properties).returns({})
     saved_search_mock.stubs(:complete!)
-    SavedSearch.expects(:new).
-      with(search_term: nil, filters: '{}').
-      returns(saved_search_mock)
+    SavedSearch.expects(:new)
+      .with(search_term: nil, filters: '{}')
+      .returns(saved_search_mock)
 
-    Download.expects(:generate).
-      with("WDPA_Jun2015_search_#{digested_pa_ids}", {wdpa_ids: pa_ids})
+    Download.expects(:generate)
+      .with("WDPA_Jun2015_search_#{digested_pa_ids}", { site_ids: pa_ids })
 
     DownloadWorkers::Search.new.perform token, nil, {}.to_json
   end
 
   test '.perform executes a search and generates a download with no search term but with a filter' do
     token = '12345'
-    pa_ids = [555556053,
-              555556054,
-              555556055,
-              555556056,
-              317192,
-              317194,
-              317193,
-              3213,
-              555556061,
-              555556057,
-              555558408,
-              555556058,
-              555558409,
-              555558410,
-              555556052,
-              2321,
-              555556062,
-              555556063,
-              555556059,
-              555556060,
-              555556064,
-              2325,
-              555556065,
-              555556067,
-              555556066,
-              2327,
-              317195,
-              5086,
-              20171,
-              902264]
+    pa_ids = [555_556_053,
+      555_556_054,
+      555_556_055,
+      555_556_056,
+      317_192,
+      317_194,
+      317_193,
+      3213,
+      555_556_061,
+      555_556_057,
+      555_558_408,
+      555_556_058,
+      555_558_409,
+      555_558_410,
+      555_556_052,
+      2321,
+      555_556_062,
+      555_556_063,
+      555_556_059,
+      555_556_060,
+      555_556_064,
+      2325,
+      555_556_065,
+      555_556_067,
+      555_556_066,
+      2327,
+      317_195,
+      5086,
+      20_171,
+      902_264]
     digested_pa_ids = '0ea0447f338935df9c9fe09cd1dd035ed3ad69f4d26e7ae50f8a1c0dec96cc8e'
 
-    saved_search_mock = mock()
-    saved_search_mock.stubs(:wdpa_ids).returns(pa_ids)
+    saved_search_mock = mock
+    saved_search_mock.stubs(:site_ids).returns(pa_ids)
     saved_search_mock.stubs(:properties).returns({})
     saved_search_mock.stubs(:complete!)
-    SavedSearch.expects(:new).
-      with(search_term: nil, filters: '{"country":"PER"}').
-      returns(saved_search_mock)
+    SavedSearch.expects(:new)
+      .with(search_term: nil, filters: '{"country":"PER"}')
+      .returns(saved_search_mock)
 
-    Download.expects(:generate).
-      with("WDPA_Jun2015_search_#{digested_pa_ids}", {wdpa_ids: pa_ids})
+    Download.expects(:generate)
+      .with("WDPA_Jun2015_search_#{digested_pa_ids}", { site_ids: pa_ids })
 
-    DownloadWorkers::Search.new.perform token, nil, {"country": "PER"}.to_json
+    DownloadWorkers::Search.new.perform token, nil, { country: 'PER' }.to_json
   end
-
 
   test '.perform, given a Search with an email, sends a completion email when the
    download is done' do
-    email = "tests@theinternetemail.com"
-    pa_ids = [1,2,3,4]
+    email = 'tests@theinternetemail.com'
+    pa_ids = [1, 2, 3, 4]
     filename = 'WDPA_Jun2015_search_03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4'
     token = 1234
 
-    saved_search_mock = mock()
-    saved_search_mock.stubs(:wdpa_ids).returns(pa_ids)
+    saved_search_mock = mock
+    saved_search_mock.stubs(:site_ids).returns(pa_ids)
 
+    SavedSearch.expects(:new)
+      .with(search_term: '', filters: '{}')
+      .returns(saved_search_mock)
 
-    SavedSearch.expects(:new).
-      with(search_term: '', filters: '{}').
-      returns(saved_search_mock)
-
-    Download::Utils.stubs(:properties).returns({'email' => email})
+    Download::Utils.stubs(:properties).returns({ 'email' => email })
     Download.stubs(:generate)
 
-    mailer_mock = mock().tap { |m| m.expects(:deliver) }
-    DownloadCompleteMailer.
-      expects(:create).
-      with(filename, email).
-      returns(mailer_mock)
+    mailer_mock = mock.tap { |m| m.expects(:deliver) }
+    DownloadCompleteMailer
+      .expects(:create)
+      .with(filename, email)
+      .returns(mailer_mock)
 
     DownloadWorkers::Search.new.perform token, '', {}.to_json
   end


### PR DESCRIPTION
- for release
   - Clean up also removes tmp_views_* views generated by the file generator
   - create_portal_downloads_view is run before the preflight stage
- Default release label is now (must be) MMMYYYY (no need to supply one anymore) unless for a different usage
- It is now using the latest release label (MMMYYYY) as the generated download file name i,e WDPA_WDOECM_Sep2025_xxxxx.zip
- The file generator is now using portal views
- Each importer is now sending a slack message after it has completed its process
- post_swap is now also reindexing the search index
- PP_RELEASE_REFRESH_VIEWS env is now true by default to make sure mvs are refreshed
- File generator is now looking for/using SITE_ID, not WDPAID
- Views are now called Materialised views, and normal views are views to separate them to be more specific.
- add clean up to rollback
- add timestamp arg to rollback task and get all available timestamps task